### PR TITLE
Add devcontainer spec

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "MAGFest Budget System",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "forwardPorts": [5000],
+  "postCreateCommand": "pip install -r requirements.txt && cp .env.example .env && flask db upgrade",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add devcontainer specification to bootstrap the local development environment using Python 3.13 image, forwarding port 5000, installing pip requirements, upgrading DB and providing useful VS Code extensions.

---
*PR created automatically by Jules for task [7976934380543714587](https://jules.google.com/task/7976934380543714587) started by @jasonspriggs*