### PR TITLE
Fixed Scope for Hotel Prices JS, changes to proxy helper obj

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -214,9 +214,8 @@ def create_app() -> Flask:
             cache[user_id] = (user.display_name or user.email) if user else str(user_id)
         return cache[user_id]
 
-    # Make get_site_content available in all templates
-    from app.routes.admin.site_content import get_site_content
-    app.jinja_env.globals['get_site_content'] = get_site_content
+    # NOTE: get_site_content is registered as a Jinja global after register_all_routes()
+    # to avoid circular imports that would cause the RouteHelpers (h) to be None.
 
     # Import models so migrations can detect them
     from . import models  # noqa: F401
@@ -919,6 +918,13 @@ def create_app() -> Flask:
             has_super_admin_role=_has_super_admin_role,
         ),
     )
+
+    # Make get_site_content available in all templates
+    # This MUST be after register_all_routes() — importing site_content triggers
+    # the admin module tree, which imports h from app.routes. If h hasn't been
+    # set yet by register_all_routes(), all admin modules get h=None.
+    from app.routes.admin.site_content import get_site_content
+    app.jinja_env.globals['get_site_content'] = get_site_content
 
     # --- Bootstrap Admins (runs once on first request) ---
     _bootstrap_done = {"done": False}

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -24,8 +24,34 @@ class RouteHelpers:
     has_super_admin_role: Callable[[], bool]  # Raw DB check, ignores role override
 
 
-# Global helpers reference - set by register_all_routes()
-h: RouteHelpers | None = None
+class _HelpersProxy:
+    """Proxy that forwards attribute access to the real RouteHelpers instance.
+
+    This exists so that `from app.routes import h` works regardless of import
+    order.  Every module that imports `h` gets a reference to this same proxy
+    object.  When register_all_routes() later calls ``h._set(helpers)``, the
+    proxy starts delegating to the real helpers — and every module sees the
+    change because the proxy object identity never changes.
+    """
+
+    def __init__(self):
+        object.__setattr__(self, '_instance', None)
+
+    def _set(self, instance: RouteHelpers):
+        object.__setattr__(self, '_instance', instance)
+
+    def __getattr__(self, name):
+        inst = object.__getattribute__(self, '_instance')
+        if inst is None:
+            raise RuntimeError("Route helpers not initialized.")
+        return getattr(inst, name)
+
+    def __bool__(self):
+        return object.__getattribute__(self, '_instance') is not None
+
+
+# Global helpers proxy - populated by register_all_routes()
+h: _HelpersProxy = _HelpersProxy()
 
 
 @dataclass(frozen=True)
@@ -47,7 +73,7 @@ class UserContext:
 
 
 def _require_helpers():
-    if h is None:
+    if not h:
         raise RuntimeError("Route helpers not initialized.")
 
 
@@ -84,8 +110,7 @@ def render_admin_page(template: str, **ctx):
 
 def register_all_routes(app: Flask, helpers: RouteHelpers) -> None:
     """Register all blueprints with the Flask app."""
-    global h
-    h = helpers
+    h._set(helpers)
 
     # Current/active routes
     from .home import home_bp

--- a/app/templates/budget/work_item_edit.html
+++ b/app/templates/budget/work_item_edit.html
@@ -914,9 +914,11 @@
 
   // Room prices in cents — pulled from expense account unit_price_cents
   const roomPrices = {
-    'standard': {{ room_prices.get('standard', 0) }},
-    'executive': {{ room_prices.get('executive', 0) }},
-    'hospitality': {{ room_prices.get('hospitality', 0) }}
+    {% for item in hotel_data %}
+      {% if item.account.code == 'HTL_STD_MAGPAID' %}'standard': {{ item.unit_price_cents }},{% endif %}
+      {% if item.account.code == 'HTL_EXEC_MAGPAID' %}'executive': {{ item.unit_price_cents }},{% endif %}
+      {% if item.account.code == 'HTL_HOSP_MAGPAID' %}'hospitality': {{ item.unit_price_cents }},{% endif %}
+    {% endfor %}
   };
 
   const roomTypeNames = {

--- a/tests/integration/test_permissions.py
+++ b/tests/integration/test_permissions.py
@@ -213,6 +213,40 @@ class TestAdminRoutePermissions:
         assert response.status_code == 403
 
 
+class TestAdminWriteOperations:
+    """Admin write operations must not crash due to h being None."""
+
+    def test_admin_can_update_event_cycle(self, app, client):
+        """
+        Updating an event cycle exercises h.get_active_user_id().
+
+        This catches the regression where admin modules imported h=None
+        due to incorrect import ordering in create_app().
+        """
+        _seed_test_data(app)
+        _login(client, "test:admin")
+
+        # Get the event cycle ID
+        from app.models import EventCycle
+        with app.app_context():
+            cycle = EventCycle.query.filter_by(code="TST2026").first()
+            cycle_id = cycle.id
+
+        response = client.post(f"/admin/config/event-cycles/{cycle_id}", data={
+            "code": "TST2026",
+            "name": "Test Event 2026 Updated",
+            "is_active": "1",
+            "is_default": "1",
+            "sort_order": "1",
+        }, follow_redirects=False)
+
+        # Should redirect on success (302), not crash (500)
+        assert response.status_code in (302, 200), (
+            f"Admin write returned {response.status_code}. "
+            "If 500, h is likely None — check import order in create_app()."
+        )
+
+
 class TestDispatchPermissions:
     """Dispatch routes require budget admin (SUPER_ADMIN or WORKTYPE_ADMIN)."""
 

--- a/tests/unit/test_route_helpers_init.py
+++ b/tests/unit/test_route_helpers_init.py
@@ -1,0 +1,76 @@
+"""
+Tests that the RouteHelpers (h) global is properly initialized.
+
+Background: Admin modules do `from app.routes import h` at import time. If any module
+triggers the admin import tree before register_all_routes() sets h, every admin module
+gets h=None and all write operations (update, create) crash with AttributeError.
+
+This has regressed before when an import was moved earlier in create_app().
+"""
+
+
+class TestRouteHelpersInitialization:
+    """Verify that h is set (not None) after app creation."""
+
+    def test_h_is_set_in_routes_module(self, app):
+        """
+        After create_app(), app.routes.h must be backed by a RouteHelpers instance.
+
+        If this fails, register_all_routes() either wasn't called or was
+        called without a helpers argument.
+        """
+        import app.routes as routes_mod
+        assert routes_mod.h, (
+            "app.routes.h has no backing RouteHelpers after create_app(). "
+            "register_all_routes() was not called or failed."
+        )
+
+    def test_h_has_required_methods(self, app):
+        """Verify h has all the methods that admin routes depend on."""
+        import app.routes as routes_mod
+        h = routes_mod.h
+        assert h
+        assert callable(h.get_active_user_id)
+        assert callable(h.is_super_admin)
+        assert callable(h.get_active_user)
+        assert callable(h.active_user_roles)
+        assert callable(h.active_user_approval_group_ids)
+
+    def test_site_content_import_does_not_break_h(self, app):
+        """
+        Importing site_content (which triggers the admin module tree) must
+        not happen before register_all_routes() sets h.
+
+        This is the specific regression that occurred: get_site_content was
+        imported as a Jinja global early in create_app(), triggering the
+        admin import tree before h was set. All admin modules then got h=None.
+        """
+        import app.routes as routes_mod
+
+        # If site_content was imported too early, h in the routes module
+        # would still be set (it gets set later), but the *copied* h in
+        # each admin module would be None. We can detect this by checking
+        # that a fresh create_app() sets h before any admin imports.
+        assert routes_mod.h
+
+        # Also verify the function is available as a Jinja global
+        assert 'get_site_content' in app.jinja_env.globals, (
+            "get_site_content is not registered as a Jinja global. "
+            "It may have been removed from create_app()."
+        )
+
+    def test_admin_write_operations_have_user_id(self, app, client):
+        """
+        Admin routes that write to the database need h.get_active_user_id().
+        Simulate the call chain to verify it doesn't crash.
+        """
+        import app.routes as routes_mod
+        h = routes_mod.h
+        assert h
+
+        with app.test_request_context():
+            from flask import session
+            session["active_user_id"] = "test:admin"
+            # This is the exact call that was crashing
+            user_id = h.get_active_user_id()
+            assert user_id == "test:admin"


### PR DESCRIPTION
Admin modules use `from app.routes import h` which binds h at import                                  
  time. If any module in the admin tree is imported before
  register_all_routes() sets h (e.g. by a test importing a helper
  function), every admin module gets h=None permanently — Python caches
  the module and never re-executes the import statement.

  Replace the bare global with a _HelpersProxy object that forwards
  attribute access to the real RouteHelpers instance. Since the proxy
  is never reassigned, all modules that imported h hold a reference to
  the same proxy and see updates when register_all_routes() calls
  h._set(helpers).

  Also move the get_site_content Jinja global registration to after
  register_all_routes(), as importing site_content triggers the full
  admin module tree.