### PR TITLE
Change-to-a-_HelpersProxy-Object

### DIFF
--- a/app/models/budget.py
+++ b/app/models/budget.py
@@ -319,7 +319,7 @@ class BudgetLineDetail(db.Model):
 
     description = db.Column(db.Text, nullable=True)
 
-    work_line = db.relationship("WorkLine", backref=db.backref("budget_detail", uselist=False))
+    work_line = db.relationship("WorkLine", backref=db.backref("budget_detail", uselist=False, cascade="all, delete-orphan"))
     expense_account = db.relationship("ExpenseAccount")
     routed_approval_group = db.relationship("ApprovalGroup", foreign_keys=[routed_approval_group_id])
     spend_type = db.relationship("SpendType")

--- a/app/models/contract.py
+++ b/app/models/contract.py
@@ -70,7 +70,7 @@ class ContractLineDetail(db.Model):
     terms_summary = db.Column(db.Text, nullable=True)
     description = db.Column(db.Text, nullable=True)
 
-    work_line = db.relationship("WorkLine", backref=db.backref("contract_detail", uselist=False))
+    work_line = db.relationship("WorkLine", backref=db.backref("contract_detail", uselist=False, cascade="all, delete-orphan"))
     contract_type = db.relationship("ContractType")
     routed_approval_group = db.relationship("ApprovalGroup", foreign_keys=[routed_approval_group_id])
 

--- a/app/models/supply.py
+++ b/app/models/supply.py
@@ -108,7 +108,7 @@ class SupplyOrderLineDetail(db.Model):
     delivery_location = db.Column(db.String(256), nullable=True)
     requester_notes = db.Column(db.Text, nullable=True)
 
-    work_line = db.relationship("WorkLine", backref=db.backref("supply_detail", uselist=False))
+    work_line = db.relationship("WorkLine", backref=db.backref("supply_detail", uselist=False, cascade="all, delete-orphan"))
     item = db.relationship("SupplyItem")
     routed_approval_group = db.relationship("ApprovalGroup", foreign_keys=[routed_approval_group_id])
 


### PR DESCRIPTION
Fix WorkLine delete crash by adding cascade to detail backrefs                                           
  BudgetLineDetail, ContractLineDetail, and SupplyOrderLineDetail all                                   
  had backrefs to WorkLine without cascade configured. Deleting a
  WorkLine caused SQLAlchemy to try nulling out the detail's FK, which
  fails because work_line_id is the primary key.

  Add cascade="all, delete-orphan" to all three detail backrefs. This
  is ORM-level only — no schema/migration change needed.
