### PR TITLE
Scope approval groups per work type, restrict admin to SUPER_ADMIN

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -387,20 +387,7 @@ def create_app() -> Flask:
             PriorityLevel,
         )
 
-        # ApprovalGroups
-        if not db.session.query(ApprovalGroup).first():
-            groups = [
-                ("TECH", "Tech", True, 10),
-                ("HOTEL", "Hotel", True, 20),
-                ("OTHER", "Other", True, 30),
-            ]
-            for code, name, active, sort in groups:
-                db.session.add(
-                    ApprovalGroup(code=code, name=name, is_active=active, sort_order=sort)
-                )
-            db.session.flush()
-
-        # WorkTypes
+        # WorkTypes (seeded before approval groups so groups can reference one)
         if not db.session.query(WorkType).first():
             work_types = [
                 ("BUDGET", "Budget Request", True, 10),
@@ -408,6 +395,24 @@ def create_app() -> Flask:
             for code, name, active, sort in work_types:
                 db.session.add(
                     WorkType(code=code, name=name, is_active=active, sort_order=sort)
+                )
+            db.session.flush()
+
+        budget_wt = db.session.query(WorkType).filter_by(code="BUDGET").first()
+
+        # ApprovalGroups
+        if budget_wt and not db.session.query(ApprovalGroup).first():
+            groups = [
+                ("TECH", "Tech", True, 10),
+                ("HOTEL", "Hotel", True, 20),
+                ("OTHER", "Other", True, 30),
+            ]
+            for code, name, active, sort in groups:
+                db.session.add(
+                    ApprovalGroup(
+                        work_type_id=budget_wt.id,
+                        code=code, name=name, is_active=active, sort_order=sort,
+                    )
                 )
             db.session.flush()
 

--- a/app/models/workflow.py
+++ b/app/models/workflow.py
@@ -22,7 +22,15 @@ class ApprovalGroup(db.Model):
     __tablename__ = "approval_groups"
 
     id = db.Column(db.Integer, primary_key=True)
-    code = db.Column(db.String(32), unique=True, nullable=False, index=True)  # TECH, HOTEL, etc.
+
+    work_type_id = db.Column(
+        db.Integer,
+        db.ForeignKey("work_types.id", name="fk_approval_groups_work_type_id"),
+        nullable=False,
+        index=True,
+    )
+
+    code = db.Column(db.String(32), nullable=False, index=True)  # TECH, HOTEL, etc.
     name = db.Column(db.String(128), nullable=False)
     description = db.Column(db.Text, nullable=True)
 
@@ -33,6 +41,15 @@ class ApprovalGroup(db.Model):
     created_by_user_id = db.Column(db.String(64), nullable=True)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
     updated_by_user_id = db.Column(db.String(64), nullable=True)
+
+    work_type = db.relationship("WorkType", foreign_keys=[work_type_id])
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "work_type_id", "code",
+            name="uq_approval_groups_work_type_code",
+        ),
+    )
 
 
 class WorkType(db.Model):

--- a/app/routes/admin/approval_groups.py
+++ b/app/routes/admin/approval_groups.py
@@ -9,6 +9,7 @@ from app import db
 from app.models import (
     ApprovalGroup,
     ExpenseAccount,
+    WorkType,
     CONFIG_AUDIT_CREATE,
     CONFIG_AUDIT_UPDATE,
     CONFIG_AUDIT_ARCHIVE,
@@ -16,8 +17,8 @@ from app.models import (
 )
 from app.routes import h
 from .helpers import (
-    require_budget_admin,
-    render_budget_admin_page,
+    require_super_admin,
+    render_admin_config_page,
     log_config_change,
     track_changes,
     validate_code_length,
@@ -41,6 +42,7 @@ def _get_approval_group_or_404(group_id: int) -> ApprovalGroup:
 def _group_to_dict(group: ApprovalGroup) -> dict:
     """Convert approval group to dict for change tracking."""
     return {
+        "work_type_id": group.work_type_id,
         "code": group.code,
         "name": group.name,
         "description": group.description,
@@ -49,8 +51,19 @@ def _group_to_dict(group: ApprovalGroup) -> dict:
     }
 
 
+def _all_work_types() -> list[WorkType]:
+    """Work types selectable in the approval-group form. Includes inactive
+    work types so admins can pre-create approval groups before a work type
+    is flipped on."""
+    return (
+        db.session.query(WorkType)
+        .order_by(*sort_with_override(WorkType))
+        .all()
+    )
+
+
 @approval_groups_bp.get("/")
-@require_budget_admin
+@require_super_admin
 def list_approval_groups():
     """List all approval groups."""
     show_inactive = request.args.get("show_inactive") == "1"
@@ -88,7 +101,7 @@ def list_approval_groups():
         )
         account_counts[group.id] = count
 
-    return render_budget_admin_page(
+    return render_admin_config_page(
         "admin/approval_groups/list.html",
         groups=groups,
         account_counts=account_counts,
@@ -99,37 +112,48 @@ def list_approval_groups():
 
 
 @approval_groups_bp.get("/new")
-@require_budget_admin
+@require_super_admin
 def new_approval_group():
     """Show new approval group form."""
-    return render_budget_admin_page(
+    return render_admin_config_page(
         "admin/approval_groups/form.html",
         group=None,
+        work_types=_all_work_types(),
     )
 
 
 @approval_groups_bp.post("/")
-@require_budget_admin
+@require_super_admin
 def create_approval_group():
     """Create a new approval group."""
     code = (request.form.get("code") or "").strip().upper()
     name = (request.form.get("name") or "").strip()
+    work_type_id = safe_int_or_none(request.form.get("work_type_id"))
 
     if not code or not name:
         flash("Code and name are required", "error")
+        return redirect(url_for(".new_approval_group"))
+
+    if work_type_id is None or db.session.get(WorkType, work_type_id) is None:
+        flash("A valid work type is required", "error")
         return redirect(url_for(".new_approval_group"))
 
     # Validate code length
     if not validate_code_length(code, "Code"):
         return redirect(url_for(".new_approval_group"))
 
-    # Check for duplicate code
-    existing = db.session.query(ApprovalGroup).filter_by(code=code).first()
+    # Check for duplicate code within the same work type
+    existing = (
+        db.session.query(ApprovalGroup)
+        .filter_by(work_type_id=work_type_id, code=code)
+        .first()
+    )
     if existing:
-        flash(f"An approval group with code '{code}' already exists", "error")
+        flash(f"An approval group with code '{code}' already exists for this work type", "error")
         return redirect(url_for(".new_approval_group"))
 
     group = ApprovalGroup(
+        work_type_id=work_type_id,
         code=code,
         name=name,
         description=(request.form.get("description") or "").strip() or None,
@@ -150,7 +174,7 @@ def create_approval_group():
 
 
 @approval_groups_bp.get("/<int:group_id>")
-@require_budget_admin
+@require_super_admin
 def edit_approval_group(group_id: int):
     """Show edit form for approval group."""
     group = _get_approval_group_or_404(group_id)
@@ -162,17 +186,18 @@ def edit_approval_group(group_id: int):
         .count()
     )
 
-    return render_budget_admin_page(
+    return render_admin_config_page(
         "admin/approval_groups/form.html",
         group=group,
         account_count=account_count,
+        work_types=_all_work_types(),
     )
 
 
 @approval_groups_bp.post("/<int:group_id>")
-@require_budget_admin
+@require_super_admin
 def update_approval_group(group_id: int):
-    """Update an approval group."""
+    """Update an approval group. Work type is locked once a group exists."""
     group = _get_approval_group_or_404(group_id)
 
     old_values = _group_to_dict(group)
@@ -188,13 +213,14 @@ def update_approval_group(group_id: int):
     if not validate_code_length(code, "Code"):
         return redirect(url_for(".edit_approval_group", group_id=group_id))
 
-    # Check for duplicate code
+    # Check for duplicate code within the same work type
     existing = db.session.query(ApprovalGroup).filter(
+        ApprovalGroup.work_type_id == group.work_type_id,
         ApprovalGroup.code == code,
-        ApprovalGroup.id != group_id
+        ApprovalGroup.id != group_id,
     ).first()
     if existing:
-        flash(f"An approval group with code '{code}' already exists", "error")
+        flash(f"An approval group with code '{code}' already exists for this work type", "error")
         return redirect(url_for(".edit_approval_group", group_id=group_id))
 
     group.code = code
@@ -215,7 +241,7 @@ def update_approval_group(group_id: int):
 
 
 @approval_groups_bp.post("/<int:group_id>/archive")
-@require_budget_admin
+@require_super_admin
 def archive_approval_group(group_id: int):
     """Archive (soft-delete) an approval group."""
     group = _get_approval_group_or_404(group_id)
@@ -235,7 +261,7 @@ def archive_approval_group(group_id: int):
 
 
 @approval_groups_bp.post("/<int:group_id>/restore")
-@require_budget_admin
+@require_super_admin
 def restore_approval_group(group_id: int):
     """Restore an archived approval group."""
     group = _get_approval_group_or_404(group_id)

--- a/app/routing/registry.py
+++ b/app/routing/registry.py
@@ -90,4 +90,14 @@ def get_approval_group_for_line(line: "WorkLine") -> Optional["ApprovalGroup"]:
 
     config = work_type.config
     strategy = get_routing_strategy(config.routing_strategy, config)
-    return strategy.get_approval_group(line)
+    group = strategy.get_approval_group(line)
+
+    if group is not None and group.work_type_id != work_type.id:
+        raise ValueError(
+            f"Routing produced a cross-work-type approval group: "
+            f"line {line.id} (work_type_id={work_type.id}) routed to "
+            f"group {group.code!r} (work_type_id={group.work_type_id}). "
+            f"Approval groups must belong to the same work type as the line."
+        )
+
+    return group

--- a/app/seeds/config_seed.py
+++ b/app/seeds/config_seed.py
@@ -48,9 +48,13 @@ from app.models import (
 )
 
 
-def seed_approval_groups() -> dict[str, ApprovalGroup]:
-    """Seed TECH, HOTEL, OTHER approval groups."""
+def seed_approval_groups(work_types: dict[str, WorkType]) -> dict[str, ApprovalGroup]:
+    """Seed approval groups. Existing seeded groups all belong to BUDGET."""
     print("Seeding approval groups...")
+
+    budget_wt = work_types.get("BUDGET")
+    if budget_wt is None:
+        raise RuntimeError("BUDGET work type must be seeded before approval groups")
 
     groups_data = [
         ("LOGISTICS", "Logistics / Warehouse", "Items that should be reviewed by the logistics or warehouse teams", 10),
@@ -64,12 +68,17 @@ def seed_approval_groups() -> dict[str, ApprovalGroup]:
 
     groups = {}
     for code, name, description, sort_order in groups_data:
-        existing = db.session.query(ApprovalGroup).filter_by(code=code).first()
+        existing = (
+            db.session.query(ApprovalGroup)
+            .filter_by(code=code, work_type_id=budget_wt.id)
+            .first()
+        )
         if existing:
             groups[code] = existing
             continue
 
         group = ApprovalGroup(
+            work_type_id=budget_wt.id,
             code=code,
             name=name,
             description=description,
@@ -781,8 +790,8 @@ def run_all_seeds():
     print("Running configuration seeds...")
     print("=" * 60)
 
-    approval_groups = seed_approval_groups()
     work_types = seed_work_types()
+    approval_groups = seed_approval_groups(work_types)
     seed_work_type_configs(work_types)
     seed_contract_types(approval_groups)
     seed_supply_categories(approval_groups)

--- a/app/templates/admin/approval_groups/form.html
+++ b/app/templates/admin/approval_groups/form.html
@@ -22,12 +22,29 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="grid" style="grid-template-columns: 1fr 1fr; gap: 16px;">
 
+      <div style="grid-column: 1 / -1;">
+        <label for="work_type_id" class="form-label">Work Type</label>
+        {% if group %}
+          <input type="text" readonly
+                 value="{{ group.work_type.name }} ({{ group.work_type.code }})" />
+          <div class="muted small mt-4">Work type cannot be changed after a group is created — it would break routing snapshots and reviewer memberships.</div>
+        {% else %}
+          <select id="work_type_id" name="work_type_id" required>
+            <option value="">— Select work type —</option>
+            {% for wt in work_types %}
+              <option value="{{ wt.id }}">{{ wt.name }} ({{ wt.code }}){% if not wt.is_active %} — inactive{% endif %}</option>
+            {% endfor %}
+          </select>
+          <div class="muted small mt-4">Approval groups belong to a single work type. Inactive work types can still receive groups so they're ready when activated.</div>
+        {% endif %}
+      </div>
+
       <div>
         <label for="code" class="form-label">Code</label>
         <input id="code" name="code" type="text" required maxlength="16"
                value="{{ group.code if group else '' }}"
                placeholder="e.g. TECH" />
-        <div class="muted small mt-4">Unique identifier (max 16 chars). Will be uppercased.</div>
+        <div class="muted small mt-4">Unique identifier within the work type (max 16 chars). Will be uppercased.</div>
       </div>
 
       <div>

--- a/app/templates/admin/approval_groups/list.html
+++ b/app/templates/admin/approval_groups/list.html
@@ -37,6 +37,7 @@
 <table>
   <thead>
     <tr>
+      <th style="width: 110px;">Work Type</th>
       <th style="width: 100px;">{{ sort_header('code', 'Code', sort_by, sort_dir) }}</th>
       <th style="width: 200px;">{{ sort_header('name', 'Name', sort_by, sort_dir) }}</th>
       <th>Description</th>
@@ -49,6 +50,7 @@
   <tbody>
     {% for group in groups %}
       <tr>
+        <td class="num small">{{ group.work_type.code }}</td>
         <td class="num">{{ group.code }}</td>
         <td>{{ group.name }}</td>
         <td class="muted small">{{ group.description or '—' }}</td>
@@ -67,7 +69,7 @@
       </tr>
     {% else %}
       <tr>
-        <td colspan="7" class="muted">No reviewer groups found.</td>
+        <td colspan="8" class="muted">No reviewer groups found.</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/app/templates/components/_top_nav.html
+++ b/app/templates/components/_top_nav.html
@@ -15,7 +15,6 @@
         <a href="{{ url_for('admin_final.all_requests') }}">All Requests</a>
         <div class="top-nav-divider"></div>
         <a href="{{ url_for('admin_config.expense_accounts.list_expense_accounts') }}">Expense Accounts</a>
-        <a href="{{ url_for('admin_config.approval_groups.list_approval_groups') }}">Reviewer Groups</a>
         <div class="top-nav-divider"></div>
         <a href="{{ url_for('admin_final.budget_admin_home') }}">Budget Admin Home</a>
       </div>
@@ -57,6 +56,7 @@
         <a href="{{ url_for('admin_config.divisions.list_divisions') }}">Divisions</a>
         <a href="{{ url_for('admin_config.departments.list_departments') }}">Departments</a>
         <a href="{{ url_for('admin_config.event_cycles.list_event_cycles') }}">Event Cycles</a>
+        <a href="{{ url_for('admin_config.approval_groups.list_approval_groups') }}">Reviewer Groups</a>
         <div class="top-nav-divider"></div>
         <a href="{{ url_for('admin_config.email_templates.list_email_templates') }}">Email Templates</a>
         <a href="{{ url_for('admin_config.site_content.list_site_content') }}">Site Content</a>

--- a/migrations/versions/p6q7r8s9t0u1_add_work_type_id_to_approval_groups.py
+++ b/migrations/versions/p6q7r8s9t0u1_add_work_type_id_to_approval_groups.py
@@ -1,0 +1,87 @@
+"""Add work_type_id to approval_groups
+
+Each approval group now belongs to one work type so different work types can
+own their own queues (e.g. BUDGET / TECH vs TECHOPS / TECHOPS_NET). The
+`code` uniqueness becomes scoped to (work_type_id, code) so different work
+types can reuse codes like GEN.
+
+Revision ID: p6q7r8s9t0u1
+Revises: o5p6q7r8s9t0
+Create Date: 2026-04-29 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'p6q7r8s9t0u1'
+down_revision = 'o5p6q7r8s9t0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Step 1: add nullable column so existing rows survive insertion
+    with op.batch_alter_table('approval_groups', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('work_type_id', sa.Integer(), nullable=True))
+
+    # Step 2: backfill existing rows with the BUDGET work type id. Existing
+    # approval groups (LOGISTICS, OFFICE, GEN, GUEST, TECH, HOTEL, etc.) all
+    # belong to BUDGET — that's the only work type that has groups today.
+    bind = op.get_bind()
+    budget_id = bind.execute(
+        sa.text("SELECT id FROM work_types WHERE code = 'BUDGET'")
+    ).scalar()
+
+    if budget_id is None:
+        # Fresh database with no seeded work types yet — nothing to backfill.
+        # The seed will create groups with work_type_id populated directly.
+        pass
+    else:
+        bind.execute(
+            sa.text(
+                "UPDATE approval_groups SET work_type_id = :wt WHERE work_type_id IS NULL"
+            ),
+            {"wt": budget_id},
+        )
+
+    # Step 3: tighten the column, swap unique-on-code for composite unique,
+    # and add the FK + supporting index.
+    with op.batch_alter_table('approval_groups', schema=None) as batch_op:
+        batch_op.alter_column('work_type_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.create_foreign_key(
+            'fk_approval_groups_work_type_id',
+            'work_types',
+            ['work_type_id'], ['id'],
+        )
+        batch_op.create_index(
+            batch_op.f('ix_approval_groups_work_type_id'),
+            ['work_type_id'],
+            unique=False,
+        )
+        # Drop the global unique on code, recreate as a plain index.
+        batch_op.drop_index(batch_op.f('ix_approval_groups_code'))
+        batch_op.create_index(
+            batch_op.f('ix_approval_groups_code'),
+            ['code'],
+            unique=False,
+        )
+        batch_op.create_unique_constraint(
+            'uq_approval_groups_work_type_code',
+            ['work_type_id', 'code'],
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('approval_groups', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_approval_groups_work_type_code', type_='unique')
+        batch_op.drop_index(batch_op.f('ix_approval_groups_code'))
+        batch_op.create_index(
+            batch_op.f('ix_approval_groups_code'),
+            ['code'],
+            unique=True,
+        )
+        batch_op.drop_index(batch_op.f('ix_approval_groups_work_type_id'))
+        batch_op.drop_constraint('fk_approval_groups_work_type_id', type_='foreignkey')
+        batch_op.drop_column('work_type_id')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,7 @@ def seed_workflow_data(app):
     db.session.add(wtc)
 
     ag = ApprovalGroup(
+        work_type_id=wt.id,
         code="TECH", name="Tech Team", is_active=True,
     )
     db.session.add(ag)


### PR DESCRIPTION
Approval groups now belong to a single work type via the newwork_type_id FK. Code uniqueness is scoped to (work_type_id, code) so  different work types can reuse codes like GEN. Routing strategies  verify the group's work type matches the line's work type at the  single entry point in routing/registry.py.

The admin/approval_groups CRUD routes are tightened from  require_budget_admin to require_super_admin, and the nav link moves  from the Budget Admin dropdown to the Admin dropdown to match. Form  shows a work-type dropdown on create (including inactive types so  TECHOPS groups can be pre-staged) and a locked display on edit.

 Migration backfills existing rows to BUDGET, swaps the global unique on code for a composite unique, and adds a supporting index.
