### PR TITLE
Fix home approver-stats query to be worktype-agnostic

### DIFF
--- a/app/routes/home.py
+++ b/app/routes/home.py
@@ -18,11 +18,12 @@ from app.models import (
     UserRole,
     WorkItem,
     WorkLine,
+    WorkLineReview,
     WorkPortfolio,
     WorkType,
     WorkTypeConfig,
-    BudgetLineDetail,
-    ExpenseAccount,
+    REVIEW_STAGE_APPROVAL_GROUP,
+    REVIEW_STATUS_PENDING,
     WORK_ITEM_STATUS_AWAITING_DISPATCH,
 )
 from app.routes.work.helpers import (
@@ -394,13 +395,18 @@ def index():
 
     # Get stats for approvers
     if approval_groups:
-        # Count lines pending review in user's approval groups
+        # Count pending approval-group reviews routed to user's groups (worktype-agnostic).
+        # Reads the routing snapshot on WorkLineReview, not the live expense-account
+        # mapping — keeps the count consistent with the actual approvals queue.
         pending_for_approver = (
-            db.session.query(WorkLine)
-            .join(BudgetLineDetail, BudgetLineDetail.work_line_id == WorkLine.id)
-            .join(ExpenseAccount, ExpenseAccount.id == BudgetLineDetail.expense_account_id)
-            .filter(ExpenseAccount.approval_group_id.in_(user_ctx.approval_group_ids))
-            .filter(WorkLine.status == "PENDING")
+            db.session.query(WorkLineReview)
+            .join(WorkLine, WorkLine.id == WorkLineReview.work_line_id)
+            .join(WorkItem, WorkItem.id == WorkLine.work_item_id)
+            .filter(WorkLineReview.stage == REVIEW_STAGE_APPROVAL_GROUP)
+            .filter(WorkLineReview.status == REVIEW_STATUS_PENDING)
+            .filter(WorkLineReview.approval_group_id.in_(user_ctx.approval_group_ids))
+            .filter(WorkItem.is_archived == False)
+            .filter(WorkItem.status == "SUBMITTED")
             .count()
         )
         context["pending_for_approver"] = pending_for_approver


### PR DESCRIPTION
## Summary
  - Replaces the BUDGET-only approver-stats query in `home.py:396-411` with a worktype-agnostic query   
  against `WorkLineReview`.
  - Drops `BudgetLineDetail` + `ExpenseAccount` joins (which excluded non-BUDGET lines entirely); adds  
  `WorkLineReview`, `REVIEW_STAGE_APPROVAL_GROUP`, `REVIEW_STATUS_PENDING` to imports.

  ## Why
  The previous query inner-joined `BudgetLineDetail` and `ExpenseAccount`, so once TechOps activates,   
  NetOps approvers would see "0 pending" on the home dashboard regardless of how many TechOps reviews   
  were routed to their group. This silently undercounts non-BUDGET reviewer queues.

  The fix also addresses two latent bugs that existed before this PR:
  - **Snapshot vs live routing.** Old query routed via `ExpenseAccount.approval_group_id` (the *live*   
  value on the expense account today). If an expense account's group was reassigned after dispatch, the 
  home count would diverge from the actual review queue (which reads the snapshot on
  `WorkLineReview.approval_group_id`). New query reads the snapshot directly and stays consistent with  
  the queue.
  - **Missing `is_archived` filter.** Sibling home stats (`submitted_count`, `dispatch_queue_count`,    
  `requests_needing_review`, `finalized_count`) all filter `WorkItem.is_archived == False`. The buggy   
  query didn't, silently inflating the count with archived items' lines.

  ## Semantics shift
  Counts `WorkLineReview` rows instead of `WorkLine` rows. For typical BUDGET dispatches (one line → one
   group) the count is unchanged. For lines dispatched to multiple groups, each group now sees its own  
  pending review counted independently
