### PR TITLE
Hide unbuilt worktypes; add per-event early-supplementary flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,17 @@
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
     - repo: https://github.com/trailofbits/pip-audit
       rev: v2.10.0
       hooks:
         - id: pip-audit
           args: ["-r", "requirements.txt", "--strict"]
+
+    - repo: local
+      hooks:
+        - id: pytest
+          name: pytest (full suite)
+          entry: pytest --tb=short -q
+          language: system
+          pass_filenames: false
+          stages: [pre-push]

--- a/app/models/org.py
+++ b/app/models/org.py
@@ -22,6 +22,11 @@ class EventCycle(db.Model):
     sort_order = db.Column(db.Integer, nullable=True, default=None)
     qb_class = db.Column(db.String(128), nullable=True)
 
+    # When True, supplementary budget requests can be created before the
+    # primary is FINALIZED. Used for events like the FY corporate-budget
+    # cycle where a department splits its budget across sibling requests.
+    allow_early_supplementary = db.Column(db.Boolean, nullable=False, default=False)
+
     # Key dates for the budget cycle
     dates_are_public = db.Column(db.Boolean, nullable=False, default=False)
     event_start_date = db.Column(db.Date, nullable=True)          # When the event starts

--- a/app/routes/admin/__init__.py
+++ b/app/routes/admin/__init__.py
@@ -19,6 +19,7 @@ from .supply_categories import supply_categories_bp
 from .supply_items import supply_items_bp
 from .email_templates import email_templates_bp
 from .site_content import site_content_bp
+from .work_types import work_types_bp
 
 admin_config_bp = Blueprint('admin_config', __name__, url_prefix='/admin/config')
 
@@ -37,3 +38,4 @@ admin_config_bp.register_blueprint(supply_categories_bp)
 admin_config_bp.register_blueprint(supply_items_bp)
 admin_config_bp.register_blueprint(email_templates_bp)
 admin_config_bp.register_blueprint(site_content_bp)
+admin_config_bp.register_blueprint(work_types_bp)

--- a/app/routes/admin/event_cycles.py
+++ b/app/routes/admin/event_cycles.py
@@ -84,6 +84,7 @@ def _cycle_to_dict(cycle: EventCycle) -> dict:
         "is_default": cycle.is_default,
         "sort_order": cycle.sort_order,
         "qb_class": cycle.qb_class,
+        "allow_early_supplementary": cycle.allow_early_supplementary,
         "dates_are_public": cycle.dates_are_public,
         "event_start_date": cycle.event_start_date.isoformat() if cycle.event_start_date else None,
         "event_end_date": cycle.event_end_date.isoformat() if cycle.event_end_date else None,
@@ -195,6 +196,7 @@ def create_event_cycle():
         is_default=is_default,
         sort_order=safe_int_or_none(request.form.get("sort_order")),
         qb_class=(request.form.get("qb_class") or "").strip() or None,
+        allow_early_supplementary=request.form.get("allow_early_supplementary") == "1",
         dates_are_public=request.form.get("dates_are_public") == "1",
         event_start_date=_parse_date(request.form.get("event_start_date")),
         event_end_date=_parse_date(request.form.get("event_end_date")),
@@ -295,6 +297,7 @@ def update_event_cycle(cycle_id: int):
     cycle.is_default = is_default
     cycle.sort_order = safe_int_or_none(request.form.get("sort_order"))
     cycle.qb_class = (request.form.get("qb_class") or "").strip() or None
+    cycle.allow_early_supplementary = request.form.get("allow_early_supplementary") == "1"
     cycle.dates_are_public = request.form.get("dates_are_public") == "1"
     cycle.event_start_date = _parse_date(request.form.get("event_start_date"))
     cycle.event_end_date = _parse_date(request.form.get("event_end_date"))

--- a/app/routes/admin/work_types.py
+++ b/app/routes/admin/work_types.py
@@ -1,0 +1,118 @@
+"""
+Admin routes for work type activation.
+
+Work types themselves are seed-only — code, slug, public_id_prefix and
+line_detail_type are wired across the codebase and cannot be changed at
+runtime. The only admin operation surfaced here is toggling
+``is_active``, which controls whether the worktype appears in the
+request-creation pickers, role assignment forms, and division/
+department work-type access editors. Already-created portfolios remain
+reachable by direct URL even when their work type is inactive.
+"""
+from __future__ import annotations
+
+from flask import Blueprint, redirect, url_for, abort, flash
+
+from sqlalchemy import func
+
+from app import db
+from app.models import (
+    ApprovalGroup,
+    WorkPortfolio,
+    WorkType,
+    CONFIG_AUDIT_ARCHIVE,
+    CONFIG_AUDIT_RESTORE,
+)
+from .helpers import (
+    require_super_admin,
+    render_admin_config_page,
+    log_config_change,
+    sort_with_override,
+)
+
+work_types_bp = Blueprint('work_types', __name__, url_prefix='/work-types')
+
+
+def _get_work_type_or_404(work_type_id: int) -> WorkType:
+    work_type = db.session.get(WorkType, work_type_id)
+    if not work_type:
+        abort(404, "Work type not found")
+    return work_type
+
+
+@work_types_bp.get("/")
+@require_super_admin
+def list_work_types():
+    """List all work types with active/inactive status and usage counts."""
+    work_types = (
+        db.session.query(WorkType)
+        .order_by(*sort_with_override(WorkType))
+        .all()
+    )
+
+    portfolio_counts = dict(
+        db.session.query(
+            WorkPortfolio.work_type_id,
+            func.count(WorkPortfolio.id),
+        ).group_by(WorkPortfolio.work_type_id).all()
+    )
+
+    approval_group_counts = dict(
+        db.session.query(
+            ApprovalGroup.work_type_id,
+            func.count(ApprovalGroup.id),
+        ).filter(ApprovalGroup.is_active == True).group_by(ApprovalGroup.work_type_id).all()
+    )
+
+    return render_admin_config_page(
+        "admin/work_types/list.html",
+        work_types=work_types,
+        portfolio_counts=portfolio_counts,
+        approval_group_counts=approval_group_counts,
+    )
+
+
+@work_types_bp.post("/<int:work_type_id>/archive")
+@require_super_admin
+def deactivate_work_type(work_type_id: int):
+    """Mark a work type inactive (hides from new-entry pickers)."""
+    work_type = _get_work_type_or_404(work_type_id)
+
+    if not work_type.is_active:
+        flash(f"{work_type.name} is already inactive", "warning")
+        return redirect(url_for(".list_work_types"))
+
+    work_type.is_active = False
+    log_config_change(
+        "work_type",
+        work_type.id,
+        CONFIG_AUDIT_ARCHIVE,
+        {"is_active": {"old": True, "new": False}},
+    )
+
+    db.session.commit()
+    flash(f"Deactivated work type: {work_type.name}", "success")
+    return redirect(url_for(".list_work_types"))
+
+
+@work_types_bp.post("/<int:work_type_id>/restore")
+@require_super_admin
+def activate_work_type(work_type_id: int):
+    """Mark a work type active (shows in pickers again)."""
+    work_type = _get_work_type_or_404(work_type_id)
+
+    if work_type.is_active:
+        flash(f"{work_type.name} is already active", "warning")
+        return redirect(url_for(".list_work_types"))
+
+    work_type.is_active = True
+    log_config_change(
+        "work_type",
+        work_type.id,
+        CONFIG_AUDIT_RESTORE,
+        {"is_active": {"old": False, "new": True}},
+    )
+
+    db.session.commit()
+    flash(f"Activated work type: {work_type.name}", "success")
+    return redirect(url_for(".list_work_types"))

--- a/app/routes/work/helpers/context.py
+++ b/app/routes/work/helpers/context.py
@@ -316,11 +316,15 @@ def build_portfolio_perms(ctx: PortfolioContext) -> PortfolioPerms:
     # Can create PRIMARY: can_edit AND no existing PRIMARY
     can_create_primary = can_edit and (existing_primary is None)
 
-    # Can create SUPPLEMENTARY: can_edit AND PRIMARY is FINALIZED
-    can_create_supplementary = can_edit and (
-        existing_primary is not None and
-        existing_primary.status == WORK_ITEM_STATUS_FINALIZED
+    # Can create SUPPLEMENTARY: can_edit AND PRIMARY exists.
+    # By default the PRIMARY must also be FINALIZED, but events with
+    # ``allow_early_supplementary`` (e.g. FY corporate-budget cycles)
+    # waive the FINALIZED gate.
+    primary_ready = existing_primary is not None and (
+        ctx.event_cycle.allow_early_supplementary
+        or existing_primary.status == WORK_ITEM_STATUS_FINALIZED
     )
+    can_create_supplementary = can_edit and primary_ready
 
     return PortfolioPerms(
         can_view=can_view,

--- a/app/routes/work/work_items/create.py
+++ b/app/routes/work/work_items/create.py
@@ -144,7 +144,10 @@ def supplementary_new(event: str, dept: str, work_type_slug: str = "budget"):
                 dept=dept,
             ))
 
-        if existing.status != WORK_ITEM_STATUS_FINALIZED:
+        if (
+            existing.status != WORK_ITEM_STATUS_FINALIZED
+            and not ctx.event_cycle.allow_early_supplementary
+        ):
             flash("The Primary Budget Request must be finalized before creating a supplementary.", "warning")
             return redirect(url_for(
                 "work.work_item_detail",
@@ -195,7 +198,10 @@ def supplementary_create(event: str, dept: str, work_type_slug: str = "budget"):
             dept=dept,
         ))
 
-    if existing_primary.status != WORK_ITEM_STATUS_FINALIZED:
+    if (
+        existing_primary.status != WORK_ITEM_STATUS_FINALIZED
+        and not ctx.event_cycle.allow_early_supplementary
+    ):
         flash("The Primary Budget Request must be finalized before creating a supplementary.", "warning")
         return redirect(url_for(
             "work.work_item_detail",

--- a/app/seeds/bootstrap.py
+++ b/app/seeds/bootstrap.py
@@ -57,13 +57,15 @@ def seed_work_types() -> dict[str, WorkType]:
     """
     print("Seeding work types...")
 
-    # is_active=False for work types whose UI isn't built yet — keeps them
-    # out of user-facing pickers but lets URL routing resolve their slugs.
+    # is_active=False for work types whose UI isn't built yet (CONTRACT,
+    # SUPPLY) or that should opt-in per environment (TECHOPS is enabled
+    # in staging only via the admin Work Types page after seeding).
+    # Inactive worktypes still let URL routing resolve their slugs.
     work_types_data = [
         ("BUDGET", "Budget Requests", 10, True),
-        ("CONTRACT", "Contracts", 20, True),
-        ("SUPPLY", "Supply Orders", 30, True),
-        ("TECHOPS", "TechOps Services", 40, True),
+        ("CONTRACT", "Contracts", 20, False),
+        ("SUPPLY", "Supply Orders", 30, False),
+        ("TECHOPS", "TechOps Services", 40, False),
         ("AV", "AV Requests", 50, False),
     ]
 

--- a/app/templates/admin/event_cycles/form.html
+++ b/app/templates/admin/event_cycles/form.html
@@ -78,6 +78,22 @@
     </div>
 
     <div style="border-top: 1px solid #eee; margin-top: 20px; padding-top: 20px;">
+      <h3 style="margin: 0 0 16px 0; font-size: 1rem;">Budget Workflow Options</h3>
+
+      <label style="display: flex; gap: 8px; align-items: flex-start; font-weight: normal;">
+        <input type="checkbox" name="allow_early_supplementary" value="1"
+               style="margin-top: 4px;"
+               {% if cycle and cycle.allow_early_supplementary %}checked{% endif %} />
+        <span>
+          Allow supplementary budget requests before the primary is finalized
+          <div class="muted small mt-4">
+            By default, departments must wait for the Primary Budget Request to be finalized before creating supplementaries. Enable this for events like the FY corporate-budget cycle, where a department intentionally splits its budget across sibling requests (e.g. capex + opex). A primary request must still exist; only the FINALIZED gate is removed.
+          </div>
+        </span>
+      </label>
+    </div>
+
+    <div style="border-top: 1px solid #eee; margin-top: 20px; padding-top: 20px;">
       <h3 style="margin: 0 0 16px 0; font-size: 1rem;">Key Dates</h3>
       <div class="muted small mb-16">
         Budget timeline dates are always shown on the homepage. Event dates (start/end) are only shown when marked as public below.

--- a/app/templates/admin/work_types/list.html
+++ b/app/templates/admin/work_types/list.html
@@ -1,0 +1,63 @@
+{% extends "layout/base.html" %}
+
+{% block title %}Work Types - Admin{% endblock %}
+
+{% block content %}
+<h1>Work Types</h1>
+<div class="muted mb-16">
+  Activate or deactivate work types. Inactive work types are hidden from request-creation pickers, division/department access editors, and role assignment forms, but already-created portfolios remain reachable by direct URL. Work type codes, slugs, and IDs are seed-only and cannot be changed.
+</div>
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 100px;">Code</th>
+      <th style="width: 220px;">Name</th>
+      <th style="width: 80px;">Priority</th>
+      <th style="width: 100px;">Portfolios</th>
+      <th style="width: 110px;">Reviewer Groups</th>
+      <th style="width: 90px;">Status</th>
+      <th style="width: 140px;">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for wt in work_types %}
+      <tr>
+        <td class="num">{{ wt.code }}</td>
+        <td>{{ wt.name }}</td>
+        <td class="num">{{ wt.sort_order if wt.sort_order is not none else '—' }}</td>
+        <td class="num">{{ portfolio_counts.get(wt.id, 0) }}</td>
+        <td class="num">{{ approval_group_counts.get(wt.id, 0) }}</td>
+        <td>
+          {% if wt.is_active %}
+            <span class="pill" style="background: #e9f7ef;">Active</span>
+          {% else %}
+            <span class="pill" style="background: #fbeaea;">Inactive</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if wt.is_active %}
+            <form method="post" action="{{ url_for('admin_config.work_types.deactivate_work_type', work_type_id=wt.id) }}" style="display: inline;">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button class="btn" type="submit" data-confirm="Deactivate {{ wt.name }}? It will be hidden from new-entry pickers.">Deactivate</button>
+            </form>
+          {% else %}
+            <form method="post" action="{{ url_for('admin_config.work_types.activate_work_type', work_type_id=wt.id) }}" style="display: inline;">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button class="btn btn-primary" type="submit">Activate</button>
+            </form>
+          {% endif %}
+        </td>
+      </tr>
+    {% else %}
+      <tr>
+        <td colspan="7" class="muted">No work types found.</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<div class="muted small" style="margin-top: 16px;">
+  {{ work_types|length }} work type(s) shown
+</div>
+{% endblock %}

--- a/app/templates/components/_top_nav.html
+++ b/app/templates/components/_top_nav.html
@@ -79,6 +79,7 @@
         <a href="{{ url_for('admin_config.divisions.list_divisions') }}">Divisions</a>
         <a href="{{ url_for('admin_config.departments.list_departments') }}">Departments</a>
         <a href="{{ url_for('admin_config.event_cycles.list_event_cycles') }}">Event Cycles</a>
+        <a href="{{ url_for('admin_config.work_types.list_work_types') }}">Work Types</a>
         <a href="{{ url_for('admin_config.approval_groups.list_approval_groups') }}">Reviewer Groups</a>
         <div class="top-nav-divider"></div>
         <a href="{{ url_for('admin_config.email_templates.list_email_templates') }}">Email Templates</a>

--- a/migrations/versions/x4y5z6a7b8c9_deactivate_unbuilt_worktypes.py
+++ b/migrations/versions/x4y5z6a7b8c9_deactivate_unbuilt_worktypes.py
@@ -1,0 +1,53 @@
+"""Deactivate CONTRACT, SUPPLY, TECHOPS work types
+
+Three work types are deactivated by this migration:
+
+* CONTRACT and SUPPLY have no requester UI yet and were appearing in the
+  request-creation pickers, confusing users who'd click in and find
+  nothing they could actually do. Hiding them via is_active=False keeps
+  any pre-existing portfolios reachable by direct URL but removes them
+  from new-entry-point pickers.
+* TECHOPS shipped to staging on 2026-04-30 but is still in beta dry-run
+  with Heather + Mark. Production should not surface it yet. Staging
+  will flip TECHOPS back to is_active=True via the new admin Work
+  Types page after this migration runs.
+
+Revision ID: x4y5z6a7b8c9
+Revises: w3x4y5z6a7b8
+Create Date: 2026-05-04 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'x4y5z6a7b8c9'
+down_revision = 'w3x4y5z6a7b8'
+branch_labels = None
+depends_on = None
+
+
+CODES_TO_DEACTIVATE = ("CONTRACT", "SUPPLY", "TECHOPS")
+
+
+def upgrade():
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE work_types SET is_active = :active "
+            "WHERE code IN :codes"
+        ).bindparams(sa.bindparam("codes", expanding=True)),
+        {"active": False, "codes": list(CODES_TO_DEACTIVATE)},
+    )
+
+
+def downgrade():
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE work_types SET is_active = :active "
+            "WHERE code IN :codes"
+        ).bindparams(sa.bindparam("codes", expanding=True)),
+        {"active": True, "codes": list(CODES_TO_DEACTIVATE)},
+    )

--- a/migrations/versions/y5z6a7b8c9d0_add_early_supplementary_flag.py
+++ b/migrations/versions/y5z6a7b8c9d0_add_early_supplementary_flag.py
@@ -1,0 +1,57 @@
+"""Add allow_early_supplementary flag to event_cycles
+
+Lets admins relax the rule that "a supplementary budget request can
+only be created after the primary is FINALIZED" on a per-event basis.
+Used for events like the FY corporate-budget cycle where a department
+intentionally splits its budget into multiple sibling requests
+(e.g. capex + opex, or rent + everything else) and shouldn't be
+forced to wait for the primary to be finalized first.
+
+Defaults to False so existing event cycles keep the strict rule.
+
+Revision ID: y5z6a7b8c9d0
+Revises: x4y5z6a7b8c9
+Create Date: 2026-05-04 12:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'y5z6a7b8c9d0'
+down_revision = 'x4y5z6a7b8c9'
+branch_labels = None
+depends_on = None
+
+
+def _has_column(bind, table: str, column: str) -> bool:
+    insp = sa.inspect(bind)
+    return any(c["name"] == column for c in insp.get_columns(table))
+
+
+def upgrade():
+    # Idempotent: in dev environments, ``db.create_all()`` may have
+    # already added the column from the model definition before this
+    # migration ran. Skip the ALTER TABLE when the column is already
+    # present so dev DBs don't fail the upgrade with "duplicate column".
+    bind = op.get_bind()
+    if _has_column(bind, 'event_cycles', 'allow_early_supplementary'):
+        return
+
+    op.add_column(
+        'event_cycles',
+        sa.Column(
+            'allow_early_supplementary',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade():
+    bind = op.get_bind()
+    if not _has_column(bind, 'event_cycles', 'allow_early_supplementary'):
+        return
+    op.drop_column('event_cycles', 'allow_early_supplementary')

--- a/tests/integration/test_work_types_admin.py
+++ b/tests/integration/test_work_types_admin.py
@@ -1,0 +1,114 @@
+"""
+Integration tests for the admin Work Types page.
+
+Work types themselves are seed-only — only ``is_active`` can be
+toggled. This admin page is what staging uses to flip TECHOPS back on
+after the deactivate-unbuilt-worktypes migration runs in production.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app import db
+from app.models import (
+    User,
+    UserRole,
+    WorkType,
+    WorkTypeConfig,
+    ROLE_SUPER_ADMIN,
+    ROUTING_STRATEGY_DIRECT,
+)
+
+
+@pytest.fixture
+def admin_setup(app):
+    """Seed a SUPER_ADMIN plus BUDGET (active) and TECHOPS (inactive) work types."""
+    admin = User(
+        id="test:admin", email="admin@test.local",
+        auth_subject="test:admin", display_name="Test Admin", is_active=True,
+    )
+    db.session.add(admin)
+    db.session.flush()
+    db.session.add(UserRole(user_id=admin.id, role_code=ROLE_SUPER_ADMIN))
+
+    budget = WorkType(code="BUDGET", name="Budget", is_active=True, sort_order=10)
+    techops = WorkType(code="TECHOPS", name="TechOps", is_active=False, sort_order=40)
+    db.session.add_all([budget, techops])
+    db.session.flush()
+
+    db.session.add(WorkTypeConfig(
+        work_type_id=budget.id, url_slug="budget",
+        public_id_prefix="BUD", line_detail_type="budget",
+        routing_strategy=ROUTING_STRATEGY_DIRECT,
+    ))
+    db.session.add(WorkTypeConfig(
+        work_type_id=techops.id, url_slug="techops",
+        public_id_prefix="TEC", line_detail_type="techops",
+        routing_strategy=ROUTING_STRATEGY_DIRECT,
+    ))
+    db.session.commit()
+
+    return {"admin": admin, "budget": budget, "techops": techops}
+
+
+@pytest.fixture
+def admin_client(client, admin_setup):
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = admin_setup["admin"].id
+    return client
+
+
+class TestWorkTypesAdmin:
+    def test_list_page_shows_active_and_inactive(self, admin_client):
+        resp = admin_client.get("/admin/config/work-types/")
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert "BUDGET" in body
+        assert "TECHOPS" in body
+
+    def test_activate_inactive_worktype(self, admin_client, admin_setup):
+        techops_id = admin_setup["techops"].id
+
+        resp = admin_client.post(
+            f"/admin/config/work-types/{techops_id}/restore",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        # Re-read from DB; the original ORM ref may be stale across the request boundary.
+        wt = db.session.get(WorkType, techops_id)
+        assert wt.is_active is True
+
+    def test_deactivate_active_worktype(self, admin_client, admin_setup):
+        budget_id = admin_setup["budget"].id
+
+        resp = admin_client.post(
+            f"/admin/config/work-types/{budget_id}/archive",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        wt = db.session.get(WorkType, budget_id)
+        assert wt.is_active is False
+
+    def test_non_admin_blocked(self, client, admin_setup):
+        # Create a non-admin user
+        regular = User(
+            id="test:regular", email="regular@test.local",
+            auth_subject="test:regular", display_name="Regular", is_active=True,
+        )
+        db.session.add(regular)
+        db.session.commit()
+
+        with client.session_transaction() as sess:
+            sess["active_user_id"] = regular.id
+
+        resp = client.post(
+            f"/admin/config/work-types/{admin_setup['techops'].id}/restore",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 403
+
+        # Confirm no state change
+        wt = db.session.get(WorkType, admin_setup["techops"].id)
+        assert wt.is_active is False

--- a/tests/unit/test_early_supplementary.py
+++ b/tests/unit/test_early_supplementary.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for the per-event ``allow_early_supplementary`` flag.
+
+The flag relaxes the rule that a Primary Budget Request must be
+FINALIZED before any Supplementary can be created. Used for events
+like the FY corporate-budget cycle where a department splits its
+budget across sibling requests.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app import db
+from app.models import (
+    Department,
+    DepartmentMembership,
+    DepartmentMembershipWorkTypeAccess,
+    EventCycle,
+    User,
+    WorkItem,
+    WorkPortfolio,
+    WorkType,
+    WorkTypeConfig,
+    REQUEST_KIND_PRIMARY,
+    ROUTING_STRATEGY_DIRECT,
+    WORK_ITEM_STATUS_DRAFT,
+    WORK_ITEM_STATUS_FINALIZED,
+)
+from app.routes import UserContext
+from app.routes.work.helpers.context import (
+    PortfolioContext,
+    build_portfolio_perms,
+)
+
+
+@pytest.fixture
+def perms_fixture(app):
+    """Seed the minimum org + portfolio + primary needed to exercise
+    build_portfolio_perms for supplementary creation."""
+    user = User(
+        id="test:editor", email="editor@test.local",
+        display_name="Editor", is_active=True,
+    )
+    cycle = EventCycle(
+        code="TST2026", name="Test Event 2026",
+        is_active=True, sort_order=1,
+    )
+    dept = Department(code="TESTDEPT", name="Test Department", is_active=True)
+    db.session.add_all([user, cycle, dept])
+
+    wt = WorkType(code="BUDGET", name="Budget", is_active=True)
+    db.session.add(wt)
+    db.session.flush()
+
+    wtc = WorkTypeConfig(
+        work_type_id=wt.id, url_slug="budget",
+        public_id_prefix="BUD", line_detail_type="budget",
+        routing_strategy=ROUTING_STRATEGY_DIRECT,
+    )
+    db.session.add(wtc)
+
+    portfolio = WorkPortfolio(
+        work_type_id=wt.id, event_cycle_id=cycle.id,
+        department_id=dept.id, created_by_user_id=user.id,
+    )
+    db.session.add(portfolio)
+    db.session.flush()
+
+    membership = DepartmentMembership(
+        user_id=user.id, department_id=dept.id, event_cycle_id=cycle.id,
+    )
+    db.session.add(membership)
+    db.session.flush()
+
+    db.session.add(DepartmentMembershipWorkTypeAccess(
+        department_membership_id=membership.id, work_type_id=wt.id,
+        can_view=True, can_edit=True,
+    ))
+
+    primary = WorkItem(
+        portfolio_id=portfolio.id,
+        request_kind=REQUEST_KIND_PRIMARY,
+        status=WORK_ITEM_STATUS_DRAFT,
+        public_id="TST2026-TESTDEPT-BUD-1",
+        created_by_user_id=user.id,
+    )
+    db.session.add(primary)
+    db.session.commit()
+
+    user_ctx = UserContext(
+        user_id=user.id,
+        user=user,
+        roles=(),
+        is_super_admin=False,
+        approval_group_ids=set(),
+    )
+
+    return {
+        "cycle": cycle, "dept": dept, "wt": wt, "portfolio": portfolio,
+        "membership": membership, "primary": primary, "user_ctx": user_ctx,
+    }
+
+
+def _make_ctx(d) -> PortfolioContext:
+    return PortfolioContext(
+        event_cycle=d["cycle"],
+        department=d["dept"],
+        portfolio=d["portfolio"],
+        work_type=d["wt"],
+        user_ctx=d["user_ctx"],
+        membership=d["membership"],
+        division_membership=None,
+    )
+
+
+class TestEarlySupplementaryFlag:
+    def test_flag_defaults_false(self, perms_fixture):
+        """Existing event cycles default to the strict rule."""
+        assert perms_fixture["cycle"].allow_early_supplementary is False
+
+    def test_strict_rule_blocks_supplementary_when_primary_is_draft(self, perms_fixture):
+        """Without the flag, a DRAFT primary blocks supplementary creation."""
+        ctx = _make_ctx(perms_fixture)
+        perms = build_portfolio_perms(ctx)
+        assert perms.can_create_supplementary is False
+
+    def test_strict_rule_allows_supplementary_when_primary_is_finalized(self, perms_fixture):
+        """Without the flag, a FINALIZED primary allows supplementary creation
+        — baseline that we haven't broken the existing path."""
+        perms_fixture["primary"].status = WORK_ITEM_STATUS_FINALIZED
+        db.session.commit()
+
+        ctx = _make_ctx(perms_fixture)
+        perms = build_portfolio_perms(ctx)
+        assert perms.can_create_supplementary is True
+
+    def test_flag_allows_supplementary_when_primary_is_draft(self, perms_fixture):
+        """With the flag set on the event, a DRAFT primary still allows
+        supplementary creation."""
+        perms_fixture["cycle"].allow_early_supplementary = True
+        db.session.commit()
+
+        ctx = _make_ctx(perms_fixture)
+        perms = build_portfolio_perms(ctx)
+        assert perms.can_create_supplementary is True
+
+    def test_flag_still_requires_primary_to_exist(self, perms_fixture):
+        """Even with the flag, a portfolio with no primary cannot host
+        a supplementary — the data invariant 'supplementaries belong to
+        a primary' is preserved."""
+        perms_fixture["cycle"].allow_early_supplementary = True
+        db.session.delete(perms_fixture["primary"])
+        db.session.commit()
+
+        ctx = _make_ctx(perms_fixture)
+        perms = build_portfolio_perms(ctx)
+        assert perms.can_create_supplementary is False

--- a/tests/unit/test_work_type_slug.py
+++ b/tests/unit/test_work_type_slug.py
@@ -67,30 +67,36 @@ class TestPortfolioContextSlug:
 
 
 class TestSeedConfigWorkTypeActivation:
-    """The seed creates TECHOPS active (T6 activation) and AV still inactive
-    (UI not yet built). Both have their slugs configured regardless of
-    activation state so URL routing resolves cleanly."""
+    """Only BUDGET ships seeded-active. CONTRACT and SUPPLY have no requester
+    UI yet and stay inactive to keep them out of pickers; TECHOPS ships
+    inactive because it is still in beta and is enabled per-environment via
+    the admin Work Types page (staging flips it on, production leaves it
+    off). All five worktypes still get their config rows created so URL
+    routing resolves cleanly even when the worktype is inactive."""
 
-    def test_techops_seeded_active_and_av_seeded_inactive(self, app):
+    def test_only_budget_seeded_active(self, app):
+        work_types = seed_work_types()
+        seed_work_type_configs(work_types)
+        db.session.commit()
+
+        budget = WorkType.query.filter_by(code="BUDGET").one()
+        assert budget.is_active is True
+
+        for code in ("CONTRACT", "SUPPLY", "TECHOPS", "AV"):
+            wt = WorkType.query.filter_by(code=code).one()
+            assert wt.is_active is False, f"{code} should ship seeded-inactive"
+
+    def test_inactive_worktypes_still_have_configs(self, app):
+        """Slugs and prefixes are still configured for inactive worktypes
+        so existing URLs and public IDs resolve."""
         work_types = seed_work_types()
         seed_work_type_configs(work_types)
         db.session.commit()
 
         techops = WorkType.query.filter_by(code="TECHOPS").one()
-        assert techops.is_active is True
         assert techops.config.url_slug == "techops"
         assert techops.config.public_id_prefix == "TEC"
 
         av = WorkType.query.filter_by(code="AV").one()
-        assert av.is_active is False
         assert av.config.url_slug == "av"
         assert av.config.public_id_prefix == "AV"
-
-    def test_existing_active_work_types_remain_active(self, app):
-        work_types = seed_work_types()
-        seed_work_type_configs(work_types)
-        db.session.commit()
-
-        for code in ("BUDGET", "CONTRACT", "SUPPLY"):
-            wt = WorkType.query.filter_by(code=code).one()
-            assert wt.is_active is True, f"{code} should remain active"


### PR DESCRIPTION
Hide unbuilt worktypes; add per-event early-supplementary flag

  Two pieces of team feedback land together because they're both event
  configuration changes:

  * CONTRACT, SUPPLY, and TECHOPS were showing in user-facing pickers
    despite incomplete/beta UI, causing confusion. A migration flips
    is_active=False in existing DBs and the seed defaults match. A new
    Admin > Work Types page lets super admins toggle is_active per
    environment, so staging can re-enable TECHOPS for dry-run while
    production stays off. URL routing intentionally still resolves
    inactive worktype slugs so already-created portfolios remain
    reachable by direct URL.

  * New EventCycle.allow_early_supplementary flag lifts the "primary
    must be FINALIZED before any supplementary" gate on a per-event
    basis. Used for events like the FY corporate-budget cycle where a
    department splits its budget across sibling requests (capex/opex,
    rent/everything-else). The "supplementary belongs to a primary"
    data invariant is preserved — only the FINALIZED gate is relaxed.

  The early-supplementary migration is idempotent (inspect-then-alter)
  so dev DBs where db.create_all() has already added the column from
  the model don't fail the upgrade.