### PR TITLE
Fix/request edit form updates

### DIFF
--- a/app/models/workflow.py
+++ b/app/models/workflow.py
@@ -476,6 +476,8 @@ class WorkItemComment(db.Model):
     body = db.Column(db.Text, nullable=False)
 
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, index=True)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow,
+                           onupdate=datetime.utcnow, index=True)
     created_by_user_id = db.Column(db.String(64), nullable=False, index=True)
 
 

--- a/app/routes/admin/helpers.py
+++ b/app/routes/admin/helpers.py
@@ -12,6 +12,7 @@ from flask import abort, render_template, flash, request
 
 # Maximum length for entity codes (departments, divisions, approval groups, etc.)
 CODE_MAX_LENGTH = 16
+MAX_FREEFORM_TEXT_LENGTH = 1000
 
 from app import db
 from app.models import (

--- a/app/routes/work/lines.py
+++ b/app/routes/work/lines.py
@@ -171,9 +171,13 @@ def line_create(event: str, dept: str, public_id: str, work_type_slug: str = "bu
     frequency_id_str = request.form.get("frequency_id", "").strip()
     priority_id_str = request.form.get("priority_id", "").strip()
     warehouse_flag = request.form.get("warehouse_flag") == "on"
-    description = request.form.get("description", "").strip()
+    description_raw = (request.form.get("description", "") or "").replace("\r\n", "\n").replace("\r", "\n")
 
+    from app.routes.admin.helpers import MAX_FREEFORM_TEXT_LENGTH
     errors = []
+    if len(description_raw) > MAX_FREEFORM_TEXT_LENGTH:
+        errors.append(f"Line description is too long (max {MAX_FREEFORM_TEXT_LENGTH:,} characters).")
+    description = description_raw.strip()
 
     # Validate expense account
     expense_account = None
@@ -488,9 +492,13 @@ def line_update(event: str, dept: str, public_id: str, line_num: int, work_type_
     frequency_id_str = request.form.get("frequency_id", "").strip()
     priority_id_str = request.form.get("priority_id", "").strip()
     warehouse_flag = request.form.get("warehouse_flag") == "on"
-    description = request.form.get("description", "").strip()
+    description_raw = (request.form.get("description", "") or "").replace("\r\n", "\n").replace("\r", "\n")
 
+    from app.routes.admin.helpers import MAX_FREEFORM_TEXT_LENGTH
     errors = []
+    if len(description_raw) > MAX_FREEFORM_TEXT_LENGTH:
+        errors.append(f"Line description is too long (max {MAX_FREEFORM_TEXT_LENGTH:,} characters).")
+    description = description_raw.strip()
 
     # Validate expense account
     expense_account = None

--- a/app/routes/work/work_items/edit.py
+++ b/app/routes/work/work_items/edit.py
@@ -328,8 +328,16 @@ def work_item_income_save(event: str, dept: str, public_id: str, work_type_slug:
     else:
         new_estimate = None
 
-    new_notes_raw = (request.form.get("income_notes") or "").strip()
-    new_notes = new_notes_raw if new_notes_raw else None
+    new_notes_raw = (request.form.get("income_notes") or "").replace("\r\n", "\n").replace("\r", "\n")
+    from app.routes.admin.helpers import MAX_FREEFORM_TEXT_LENGTH
+    if len(new_notes_raw) > MAX_FREEFORM_TEXT_LENGTH:
+        flash(f"Income notes are too long (max {MAX_FREEFORM_TEXT_LENGTH:,} characters).", "error")
+        return redirect(url_for(
+            "work.work_item_edit", event=event, dept=dept,
+            public_id=public_id, tab="notes",
+        ))
+    new_notes_stripped = new_notes_raw.strip()
+    new_notes = new_notes_stripped if new_notes_stripped else None
 
     if new_estimate != old_estimate:
         _write_work_item_audit(
@@ -789,7 +797,15 @@ def hotel_wizard_add(event: str, dept: str, public_id: str, work_type_slug: str 
     who_pays = request.form.get("who_pays", "magfest")  # magfest, third_party
     room_type = request.form.get("room_type", "standard")  # standard, executive, hospitality
     room_count = safe_int(request.form.get("room_count"), 1)
-    description = (request.form.get("description") or "").strip()
+    description_raw = (request.form.get("description") or "").replace("\r\n", "\n").replace("\r", "\n")
+    from app.routes.admin.helpers import MAX_FREEFORM_TEXT_LENGTH
+    if len(description_raw) > MAX_FREEFORM_TEXT_LENGTH:
+        flash(f"Hotel description is too long (max {MAX_FREEFORM_TEXT_LENGTH:,} characters).", "error")
+        return redirect(url_for(
+            "work.work_item_edit", event=event, dept=dept,
+            public_id=public_id, tab="hotel-services",
+        ))
+    description = description_raw.strip()
 
     # Calculate total nights
     event_nights = safe_int(request.form.get("event_nights"), 0)
@@ -959,7 +975,15 @@ def work_item_comment_edit(event: str, dept: str, public_id: str,
     if comment.created_by_user_id != user_ctx.user_id:
         abort(403)
 
-    new_body = (request.form.get("comment") or "").strip()
+    new_body_raw = (request.form.get("comment") or "").replace("\r\n", "\n").replace("\r", "\n")
+    from app.routes.admin.helpers import MAX_FREEFORM_TEXT_LENGTH
+    if len(new_body_raw) > MAX_FREEFORM_TEXT_LENGTH:
+        flash(f"Note is too long (max {MAX_FREEFORM_TEXT_LENGTH:,} characters).", "error")
+        return redirect(url_for(
+            "work.work_item_edit", event=event, dept=dept,
+            public_id=public_id, tab="notes",
+        ))
+    new_body = new_body_raw.strip()
     if not new_body:
         flash("Comment text is required.", "error")
         return redirect(url_for(

--- a/app/routes/work/work_items/edit.py
+++ b/app/routes/work/work_items/edit.py
@@ -3,7 +3,7 @@ Work item edit routes - edit form, save, fixed costs, hotel wizard.
 """
 from decimal import Decimal, InvalidOperation
 
-from flask import render_template, redirect, url_for, request, flash
+from flask import render_template, redirect, url_for, request, flash, abort
 
 from app import db
 from app.models import (
@@ -41,6 +41,25 @@ from ..helpers import (
     get_next_line_number,
 )
 from .common import get_work_item_by_public_id, calculate_event_nights
+
+
+# ============================================================
+# Audit helpers
+# ============================================================
+
+def _write_work_item_audit(work_item, event_type, *, old_value=None,
+                           new_value=None, snapshot=None, reason=None,
+                           actor_user_id):
+    """Append a WorkItemAuditEvent row. Caller is responsible for db.session.commit()."""
+    db.session.add(WorkItemAuditEvent(
+        work_item_id=work_item.id,
+        event_type=event_type,
+        old_value=old_value,
+        new_value=new_value,
+        snapshot=snapshot,
+        reason=reason,
+        created_by_user_id=actor_user_id,
+    ))
 
 
 # ============================================================
@@ -286,17 +305,20 @@ def work_item_reason_save(event: str, dept: str, public_id: str, work_type_slug:
 def work_item_income_save(event: str, dept: str, public_id: str, work_type_slug: str = "budget"):
     """
     Save income information for a DRAFT work item.
-    Income is informational only — does not affect approval workflow.
+    Writes WorkItemAuditEvent rows for any field whose value actually changed.
     """
+    user_ctx = get_user_ctx()
     work_item, ctx = get_work_item_by_public_id(event, dept, public_id, work_type_slug)
-    perms = require_work_item_edit(work_item, ctx)
+    require_work_item_edit(work_item, ctx)
 
-    # Parse dollar amount and convert to cents
+    old_estimate = work_item.income_estimate_cents
+    old_notes = work_item.income_notes
+
     amount_str = (request.form.get("income_estimate") or "").strip()
     if amount_str:
         try:
             dollars = Decimal(amount_str.replace(",", "").replace("$", ""))
-            work_item.income_estimate_cents = int(dollars * 100)
+            new_estimate = int(dollars * 100)
         except Exception:
             flash("Invalid dollar amount.", "error")
             return redirect(url_for(
@@ -304,11 +326,28 @@ def work_item_income_save(event: str, dept: str, public_id: str, work_type_slug:
                 public_id=public_id, tab="notes",
             ))
     else:
-        work_item.income_estimate_cents = None
+        new_estimate = None
 
-    # Save income notes
-    notes = (request.form.get("income_notes") or "").strip()
-    work_item.income_notes = notes if notes else None
+    new_notes_raw = (request.form.get("income_notes") or "").strip()
+    new_notes = new_notes_raw if new_notes_raw else None
+
+    if new_estimate != old_estimate:
+        _write_work_item_audit(
+            work_item, "INCOME_ESTIMATE_CHANGE",
+            old_value=str(old_estimate) if old_estimate is not None else None,
+            new_value=str(new_estimate) if new_estimate is not None else None,
+            actor_user_id=user_ctx.user_id,
+        )
+        work_item.income_estimate_cents = new_estimate
+
+    if new_notes != old_notes:
+        _write_work_item_audit(
+            work_item, "INCOME_NOTES_CHANGE",
+            old_value=old_notes,
+            new_value=new_notes,
+            actor_user_id=user_ctx.user_id,
+        )
+        work_item.income_notes = new_notes
 
     db.session.commit()
 
@@ -895,4 +934,93 @@ def hotel_wizard_add(event: str, dept: str, public_id: str, work_type_slug: str 
         dept=dept,
         public_id=public_id,
         tab="hotel-services"
+    ))
+
+
+# ============================================================
+# Note (Comment) Edit/Delete Routes — DRAFT, author-only
+# ============================================================
+
+@work_bp.post("/<event>/<dept>/<work_type_slug>/item/<public_id>/comment/<int:comment_id>/edit")
+@work_bp.post("/<event>/<dept>/budget/item/<public_id>/comment/<int:comment_id>/edit")
+def work_item_comment_edit(event: str, dept: str, public_id: str,
+                           comment_id: int, work_type_slug: str = "budget"):
+    """Edit your own DRAFT note. Author-only. Writes an audit row when the body changes."""
+    from app.models import WorkItemComment
+
+    user_ctx = get_user_ctx()
+    work_item, ctx = get_work_item_by_public_id(event, dept, public_id, work_type_slug)
+    require_work_item_edit(work_item, ctx)
+
+    comment = WorkItemComment.query.filter_by(
+        id=comment_id, work_item_id=work_item.id
+    ).first_or_404()
+
+    if comment.created_by_user_id != user_ctx.user_id:
+        abort(403)
+
+    new_body = (request.form.get("comment") or "").strip()
+    if not new_body:
+        flash("Comment text is required.", "error")
+        return redirect(url_for(
+            "work.work_item_edit", event=event, dept=dept,
+            public_id=public_id, tab="notes",
+        ))
+
+    old_body = comment.body
+    if new_body != old_body:
+        _write_work_item_audit(
+            work_item, "COMMENT_EDIT",
+            old_value=old_body, new_value=new_body,
+            snapshot={"comment_id": comment.id,
+                      "comment_created_at": comment.created_at.isoformat()},
+            actor_user_id=user_ctx.user_id,
+        )
+        comment.body = new_body
+        db.session.commit()
+        flash("Note updated.", "success")
+    else:
+        flash("No changes to save.", "info")
+
+    return redirect(url_for(
+        "work.work_item_edit", event=event, dept=dept,
+        public_id=public_id, tab="notes",
+    ))
+
+
+@work_bp.post("/<event>/<dept>/<work_type_slug>/item/<public_id>/comment/<int:comment_id>/delete")
+@work_bp.post("/<event>/<dept>/budget/item/<public_id>/comment/<int:comment_id>/delete")
+def work_item_comment_delete(event: str, dept: str, public_id: str,
+                             comment_id: int, work_type_slug: str = "budget"):
+    """Delete your own DRAFT note. Author-only. Hard-delete with full body in audit."""
+    from app.models import WorkItemComment
+
+    user_ctx = get_user_ctx()
+    work_item, ctx = get_work_item_by_public_id(event, dept, public_id, work_type_slug)
+    require_work_item_edit(work_item, ctx)
+
+    comment = WorkItemComment.query.filter_by(
+        id=comment_id, work_item_id=work_item.id
+    ).first_or_404()
+
+    if comment.created_by_user_id != user_ctx.user_id:
+        abort(403)
+
+    _write_work_item_audit(
+        work_item, "COMMENT_DELETE",
+        old_value=comment.body, new_value=None,
+        snapshot={
+            "comment_id": comment.id,
+            "comment_created_at": comment.created_at.isoformat(),
+            "comment_author_user_id": comment.created_by_user_id,
+        },
+        actor_user_id=user_ctx.user_id,
+    )
+    db.session.delete(comment)
+    db.session.commit()
+
+    flash("Note deleted.", "success")
+    return redirect(url_for(
+        "work.work_item_edit", event=event, dept=dept,
+        public_id=public_id, tab="notes",
     ))

--- a/app/routes/work/work_items/view.py
+++ b/app/routes/work/work_items/view.py
@@ -161,6 +161,15 @@ def work_item_comment(event: str, dept: str, public_id: str, work_type_slug: str
         created_by_user_id=user_ctx.user_id,
     )
     db.session.add(comment)
+    db.session.flush()  # populate comment.id for the audit snapshot
+
+    db.session.add(WorkItemAuditEvent(
+        work_item_id=work_item.id,
+        event_type="COMMENT_ADDED",
+        new_value=comment_text,
+        snapshot={"comment_id": comment.id, "visibility": visibility},
+        created_by_user_id=user_ctx.user_id,
+    ))
     db.session.commit()
 
     flash("Comment added.", "success")

--- a/app/routes/work/work_items/view.py
+++ b/app/routes/work/work_items/view.py
@@ -148,7 +148,15 @@ def work_item_comment(event: str, dept: str, public_id: str, work_type_slug: str
         flash("You do not have permission to comment on this request.", "error")
         return redirect(return_to or default_redirect)
 
-    comment_text = (request.form.get("comment") or "").strip()
+    comment_raw = (request.form.get("comment") or "").replace("\r\n", "\n").replace("\r", "\n")
+    from app.routes.admin.helpers import MAX_FREEFORM_TEXT_LENGTH
+    if len(comment_raw) > MAX_FREEFORM_TEXT_LENGTH:
+        flash(f"Note is too long (max {MAX_FREEFORM_TEXT_LENGTH:,} characters).", "error")
+        return redirect(return_to or url_for(
+            "work.work_item_edit", event=event, dept=dept,
+            public_id=public_id, tab="notes",
+        ))
+    comment_text = comment_raw.strip()
     if not comment_text:
         flash("Comment text is required.", "error")
         return redirect(return_to or default_redirect)

--- a/app/templates/admin_final/income_report.html
+++ b/app/templates/admin_final/income_report.html
@@ -113,7 +113,7 @@
                 </td>
                 <td>
                   {% if row.income_notes %}
-                    <span style="white-space: pre-wrap;">{{ row.income_notes }}</span>
+                    <span style="white-space: pre-wrap;">{{ row.income_notes|markdown_links|safe }}</span>
                   {% else %}
                     <span class="muted">-</span>
                   {% endif %}

--- a/app/templates/budget/_work_item_comments.html
+++ b/app/templates/budget/_work_item_comments.html
@@ -17,7 +17,7 @@
   {% if work_item.income_notes %}
     <div>
       <span style="font-weight: 600; font-size: 13px;">Notes:</span>
-      <span style="white-space: pre-wrap;">{{ work_item.income_notes }}</span>
+      <span style="white-space: pre-wrap;">{{ work_item.income_notes|markdown_links|safe }}</span>
     </div>
   {% endif %}
 </div>

--- a/app/templates/budget/_work_item_lines_table.html
+++ b/app/templates/budget/_work_item_lines_table.html
@@ -42,7 +42,7 @@
           </td>
           <td data-label="Details">
             {% if detail and detail.description %}
-              {{ detail.description }}
+              <div style="white-space: pre-wrap;">{{ detail.description|markdown_links|safe }}</div>
             {% else %}
               <span class="muted">-</span>
             {% endif %}

--- a/app/templates/budget/line_form.html
+++ b/app/templates/budget/line_form.html
@@ -142,6 +142,7 @@
         <label for="description"><strong>Details</strong></label>
         <textarea name="description" id="description" rows="3" class="mt-4"
                   placeholder="Please provide a detailed explanation what this line item is for...">{{ form_data.description if form_data else '' }}</textarea>
+        {% include "components/_rich_text_hint.html" %}
       </div>
 
       {# Actions #}

--- a/app/templates/budget/line_form.html
+++ b/app/templates/budget/line_form.html
@@ -140,7 +140,7 @@
       {# Description #}
       <div style="margin-top: 16px;">
         <label for="description"><strong>Details</strong></label>
-        <textarea name="description" id="description" rows="3" class="mt-4"
+        <textarea name="description" id="description" rows="3" maxlength="1000" class="mt-4"
                   placeholder="Please provide a detailed explanation what this line item is for...">{{ form_data.description if form_data else '' }}</textarea>
         {% include "components/_rich_text_hint.html" %}
       </div>

--- a/app/templates/budget/work_item_edit.html
+++ b/app/templates/budget/work_item_edit.html
@@ -176,7 +176,7 @@
                 </td>
                 <td data-label="Details">
                   {% if detail and detail.description %}
-                    {{ detail.description }}
+                    <div style="white-space: pre-wrap;">{{ detail.description|markdown_links|safe }}</div>
                   {% else %}
                     <span class="muted">-</span>
                   {% endif %}
@@ -360,7 +360,13 @@
               <td data-label="Room type">
                 <strong>{{ detail.expense_account.name if detail and detail.expense_account else '-' }}</strong>
               </td>
-              <td data-label="Description">{{ detail.description if detail else '-' }}</td>
+              <td data-label="Description">
+                {% if detail and detail.description %}
+                  <div style="white-space: pre-wrap;">{{ detail.description|markdown_links|safe }}</div>
+                {% else %}
+                  <span class="muted">-</span>
+                {% endif %}
+              </td>
               <td data-label="Nights" class="right num">{{ detail.quantity | int if detail else '-' }}</td>
               <td data-label="Total" class="right num"><strong>{{ format_currency(line_total) }}</strong></td>
               <td>
@@ -600,7 +606,8 @@
         {# Step 6: Description #}
         <div style="margin-bottom: 20px;">
           <label for="description" style="display: block; font-weight: 600; margin-bottom: 8px;">Brief description (who is this for?)</label>
-          <input type="text" name="description" id="description" placeholder="e.g. contracted suite for Saturday's headliner Ivan & the Ivans; self-paid rooms for indie devs" style="width: 100%; max-width: 500px;">
+          <textarea name="description" id="description" rows="2" placeholder="e.g. contracted suite for Saturday's headliner Ivan & the Ivans; self-paid rooms for indie devs" style="width: 100%; max-width: 500px;"></textarea>
+          {% include "components/_rich_text_hint.html" %}
         </div>
 
         {# Preview #}
@@ -755,6 +762,7 @@
           <div style="margin-bottom: 10px;">
             <label for="income_notes" style="font-size: 13px; font-weight: 600;">Income Notes:</label>
             <textarea name="income_notes" id="income_notes" rows="2" style="width: 100%; margin-top: 4px;" placeholder="Describe the source of expected income (e.g., merch sales, pilk black market)...">{{ work_item.income_notes or '' }}</textarea>
+            {% include "components/_rich_text_hint.html" %}
           </div>
           <button type="submit" class="btn btn-primary">Save Income Info</button>
         </form>
@@ -768,6 +776,7 @@
           <div style="margin-bottom: 8px;">
             <label for="comment" style="font-size: 13px; font-weight: 600;">Add Note:</label>
             <textarea name="comment" id="comment" rows="3" style="width: 100%; margin-top: 4px;" placeholder="Add context, justification, or notes for reviewers..."></textarea>
+            {% include "components/_rich_text_hint.html" %}
           </div>
           {% if user_ctx.is_super_admin %}
             <label style="display: block; margin-bottom: 8px; font-size: 13px; cursor: pointer;">
@@ -791,7 +800,7 @@
                 <span class="pill" style="margin-left: 4px;">Admin Only</span>
               {% endif %}
             </div>
-            <div style="margin-top: 4px; white-space: pre-wrap;">{{ comment.body }}</div>
+            <div style="margin-top: 4px; white-space: pre-wrap;">{{ comment.body|markdown_links|safe }}</div>
           </div>
         {% endfor %}
       {% else %}

--- a/app/templates/budget/work_item_edit.html
+++ b/app/templates/budget/work_item_edit.html
@@ -772,7 +772,7 @@
       <div style="margin-bottom: 20px; padding-bottom: 20px; border-bottom: 1px solid #eee;">
         <form method="post" action="{{ url_for('work.work_item_comment', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <input type="hidden" name="return_to" value="{{ request.url }}">
+          <input type="hidden" name="return_to" value="{{ request.path }}">
           <div style="margin-bottom: 8px;">
             <label for="comment" style="font-size: 13px; font-weight: 600;">Add Note:</label>
             <textarea name="comment" id="comment" rows="3" style="width: 100%; margin-top: 4px;" placeholder="Add context, justification, or notes for reviewers..."></textarea>

--- a/app/templates/budget/work_item_edit.html
+++ b/app/templates/budget/work_item_edit.html
@@ -792,15 +792,58 @@
       {% if comments %}
         <h4 style="margin: 0 0 12px 0; font-size: 14px;">Previous Notes</h4>
         {% for comment in comments %}
-          <div class="comment">
+          {% set is_author = (comment.created_by_user_id == user_ctx.user_id) %}
+          {% set can_manage = is_author and work_item.status == 'DRAFT' %}
+          <div class="comment" id="comment-{{ comment.id }}">
             <div class="muted small">
               {{ comment.created_at.strftime('%Y-%m-%d %H:%M') }} &middot;
               {{ comment.created_by_user_id|user_display }}
               {% if comment.visibility == "ADMIN" %}
                 <span class="pill" style="margin-left: 4px;">Admin Only</span>
               {% endif %}
+              {% if comment.updated_at and (comment.updated_at - comment.created_at).total_seconds() > 1 %}
+                <span class="muted" style="margin-left: 4px;">(edited {% if comment.updated_at.date() == comment.created_at.date() %}{{ comment.updated_at.strftime('%H:%M') }}{% else %}{{ comment.updated_at.strftime('%Y-%m-%d %H:%M') }}{% endif %})</span>
+              {% endif %}
+              {% if can_manage %}
+                <button type="button" class="btn comment-edit-btn"
+                        data-comment-id="{{ comment.id }}"
+                        style="padding: 1px 6px; font-size: 11px; margin-left: 8px;">Edit</button>
+                <form method="post"
+                      action="{{ url_for('work.work_item_comment_delete',
+                                         event=ctx.event_cycle.code,
+                                         dept=ctx.department.code,
+                                         public_id=work_item.public_id,
+                                         comment_id=comment.id) }}"
+                      style="display: inline;">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <button type="submit" class="btn"
+                          style="padding: 1px 6px; font-size: 11px; margin-left: 4px; color: #dc3545; border-color: #dc3545;"
+                          data-confirm="Delete this note? This will be recorded in the audit log.">Delete</button>
+                </form>
+              {% endif %}
             </div>
-            <div style="margin-top: 4px; white-space: pre-wrap;">{{ comment.body|markdown_links|safe }}</div>
+            <div class="comment-body" style="margin-top: 4px; white-space: pre-wrap;" id="comment-body-{{ comment.id }}">{{ comment.body|markdown_links|safe }}</div>
+            {% if can_manage %}
+              <form method="post"
+                    action="{{ url_for('work.work_item_comment_edit',
+                                       event=ctx.event_cycle.code,
+                                       dept=ctx.department.code,
+                                       public_id=work_item.public_id,
+                                       comment_id=comment.id) }}"
+                    class="comment-edit-form"
+                    id="comment-edit-form-{{ comment.id }}"
+                    style="display: none; margin-top: 8px;">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <textarea name="comment" rows="3" style="width: 100%;">{{ comment.body }}</textarea>
+                {% include "components/_rich_text_hint.html" %}
+                <div style="margin-top: 6px;">
+                  <button type="submit" class="btn btn-primary" style="padding: 4px 12px; font-size: 12px;">Save</button>
+                  <button type="button" class="btn comment-edit-cancel"
+                          data-comment-id="{{ comment.id }}"
+                          style="padding: 4px 12px; font-size: 12px;">Cancel</button>
+                </div>
+              </form>
+            {% endif %}
           </div>
         {% endfor %}
       {% else %}
@@ -1164,6 +1207,31 @@
       reasonDisplayContainer.style.display = 'block';
     });
   }
+
+  // ========== Note inline edit/cancel ==========
+  document.querySelectorAll('.comment-edit-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var id = this.dataset.commentId;
+      var form = document.getElementById('comment-edit-form-' + id);
+      var body = document.getElementById('comment-body-' + id);
+      if (form && body) {
+        form.style.display = 'block';
+        body.style.display = 'none';
+      }
+    });
+  });
+
+  document.querySelectorAll('.comment-edit-cancel').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var id = this.dataset.commentId;
+      var form = document.getElementById('comment-edit-form-' + id);
+      var body = document.getElementById('comment-body-' + id);
+      if (form && body) {
+        form.style.display = 'none';
+        body.style.display = '';
+      }
+    });
+  });
 
   // ========== Unsaved Changes Warning (page navigation) ==========
   window.addEventListener('beforeunload', function(e) {

--- a/app/templates/budget/work_item_edit.html
+++ b/app/templates/budget/work_item_edit.html
@@ -606,7 +606,7 @@
         {# Step 6: Description #}
         <div style="margin-bottom: 20px;">
           <label for="description" style="display: block; font-weight: 600; margin-bottom: 8px;">Brief description (who is this for?)</label>
-          <textarea name="description" id="description" rows="2" placeholder="e.g. contracted suite for Saturday's headliner Ivan & the Ivans; self-paid rooms for indie devs" style="width: 100%; max-width: 500px;"></textarea>
+          <textarea name="description" id="description" rows="2" maxlength="1000" placeholder="e.g. contracted suite for Saturday's headliner Ivan & the Ivans; self-paid rooms for indie devs" style="width: 100%; max-width: 500px;"></textarea>
           {% include "components/_rich_text_hint.html" %}
         </div>
 
@@ -761,7 +761,7 @@
           </div>
           <div style="margin-bottom: 10px;">
             <label for="income_notes" style="font-size: 13px; font-weight: 600;">Income Notes:</label>
-            <textarea name="income_notes" id="income_notes" rows="2" style="width: 100%; margin-top: 4px;" placeholder="Describe the source of expected income (e.g., merch sales, pilk black market)...">{{ work_item.income_notes or '' }}</textarea>
+            <textarea name="income_notes" id="income_notes" rows="2" maxlength="1000" style="width: 100%; margin-top: 4px;" placeholder="Describe the source of expected income (e.g., merch sales, pilk black market)...">{{ work_item.income_notes or '' }}</textarea>
             {% include "components/_rich_text_hint.html" %}
           </div>
           <button type="submit" class="btn btn-primary">Save Income Info</button>
@@ -775,7 +775,7 @@
           <input type="hidden" name="return_to" value="{{ request.path }}">
           <div style="margin-bottom: 8px;">
             <label for="comment" style="font-size: 13px; font-weight: 600;">Add Note:</label>
-            <textarea name="comment" id="comment" rows="3" style="width: 100%; margin-top: 4px;" placeholder="Add context, justification, or notes for reviewers..."></textarea>
+            <textarea name="comment" id="comment" rows="3" maxlength="1000" style="width: 100%; margin-top: 4px;" placeholder="Add context, justification, or notes for reviewers..."></textarea>
             {% include "components/_rich_text_hint.html" %}
           </div>
           {% if user_ctx.is_super_admin %}
@@ -834,7 +834,7 @@
                     id="comment-edit-form-{{ comment.id }}"
                     style="display: none; margin-top: 8px;">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <textarea name="comment" rows="3" style="width: 100%;">{{ comment.body }}</textarea>
+                <textarea name="comment" rows="3" maxlength="1000" style="width: 100%;">{{ comment.body }}</textarea>
                 {% include "components/_rich_text_hint.html" %}
                 <div style="margin-top: 6px;">
                   <button type="submit" class="btn btn-primary" style="padding: 4px 12px; font-size: 12px;">Save</button>

--- a/app/templates/components/_rich_text_hint.html
+++ b/app/templates/components/_rich_text_hint.html
@@ -1,8 +1,13 @@
 {# templates/components/_rich_text_hint.html
    Shared inline hint for freeform textareas in the edit form.
-   Tells users that Enter creates a newline and how to format links.
+   Tells users that Enter creates a newline and how to format links, and
+   shows a live character counter when the adjacent <textarea> has a
+   maxlength attribute. The counter is populated by the site-wide JS in
+   layout/base.html (it walks textarea[maxlength] elements and finds the
+   nearest sibling .char-counter).
    Usage:  {% include "components/_rich_text_hint.html" %}
 #}
-<div class="muted small" style="margin-top: 4px;">
-  Press Enter for a new line. Format a link as <code>[label](https://...)</code>.
+<div class="muted small" style="margin-top: 4px; display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap;">
+  <span>Press Enter for a new line. Format a link as <code>[label](https://...)</code>.</span>
+  <span class="char-counter"></span>
 </div>

--- a/app/templates/components/_rich_text_hint.html
+++ b/app/templates/components/_rich_text_hint.html
@@ -1,0 +1,8 @@
+{# templates/components/_rich_text_hint.html
+   Shared inline hint for freeform textareas in the edit form.
+   Tells users that Enter creates a newline and how to format links.
+   Usage:  {% include "components/_rich_text_hint.html" %}
+#}
+<div class="muted small" style="margin-top: 4px;">
+  Press Enter for a new line. Format a link as <code>[label](https://...)</code>.
+</div>

--- a/app/templates/layout/base.html
+++ b/app/templates/layout/base.html
@@ -958,6 +958,28 @@
       if (form) form.submit();
     }
   });
+
+  // Live character counter for any textarea[maxlength] that has a
+  // sibling .char-counter span (rendered by components/_rich_text_hint.html).
+  // Shows "N / MAX" while typing; muted gray normally, red when at the cap.
+  function setupCharCounter(ta) {
+    var max = parseInt(ta.getAttribute('maxlength'), 10);
+    if (!max) return;
+    // Find a .char-counter inside the textarea's parent (the partial renders
+    // it as a sibling element of the textarea, within the same wrapper div).
+    var parent = ta.parentElement;
+    var counter = parent ? parent.querySelector('.char-counter') : null;
+    if (!counter) return;
+    function fmt(n) { return n.toLocaleString(); }
+    function update() {
+      var len = ta.value.length;
+      counter.textContent = fmt(len) + ' / ' + fmt(max);
+      counter.style.color = (len >= max) ? '#dc3545' : '';
+    }
+    ta.addEventListener('input', update);
+    update();
+  }
+  document.querySelectorAll('textarea[maxlength]').forEach(setupCharCounter);
 })();
 </script>
 </body>

--- a/app/templates/macros/audit_log.html
+++ b/app/templates/macros/audit_log.html
@@ -98,6 +98,16 @@
               <span class="pill pill-submitted">FIELD CHANGE</span>
             {% elif event.event_type == 'LINE_DELETED' %}
               <span class="pill tag-kicked">LINE DELETED</span>
+            {% elif event.event_type == 'COMMENT_ADDED' %}
+              <span class="pill" style="background: #d1fae5; color: #065f46;">NOTE ADDED</span>
+            {% elif event.event_type == 'COMMENT_EDIT' %}
+              <span class="pill" style="background: #e0e7ff; color: #3730a3;">NOTE EDITED</span>
+            {% elif event.event_type == 'COMMENT_DELETE' %}
+              <span class="pill tag-kicked">NOTE DELETED</span>
+            {% elif event.event_type == 'INCOME_ESTIMATE_CHANGE' %}
+              <span class="pill" style="background: #dbeafe; color: #1e40af;">INCOME ESTIMATE</span>
+            {% elif event.event_type == 'INCOME_NOTES_CHANGE' %}
+              <span class="pill" style="background: #dbeafe; color: #1e40af;">INCOME NOTES</span>
             {% else %}
               <span class="pill">{{ event.event_type }}</span>
             {% endif %}
@@ -131,6 +141,27 @@
               {% else %}
                 {{ event.old_value }}
               {% endif %}
+            {% elif event.event_type == 'COMMENT_ADDED' %}
+              <div class="small" style="white-space: pre-wrap;">{{ event.new_value }}</div>
+              {% if event.snapshot and event.snapshot.visibility == 'ADMIN' %}
+                <div class="muted small" style="margin-top: 2px;">(admin-only)</div>
+              {% endif %}
+            {% elif event.event_type == 'COMMENT_EDIT' %}
+              <div class="small">
+                <div><span class="muted">From:</span> <span style="white-space: pre-wrap;">{{ event.old_value }}</span></div>
+                <div style="margin-top: 4px;"><span class="muted">To:</span> <strong style="white-space: pre-wrap;">{{ event.new_value }}</strong></div>
+              </div>
+            {% elif event.event_type == 'COMMENT_DELETE' %}
+              <div class="small" style="white-space: pre-wrap;">{{ event.old_value }}</div>
+            {% elif event.event_type == 'INCOME_ESTIMATE_CHANGE' %}
+              <span class="muted">{% if event.old_value %}${{ "%.2f"|format((event.old_value|int) / 100) }}{% else %}(none){% endif %}</span>
+              &rarr;
+              <strong>{% if event.new_value %}${{ "%.2f"|format((event.new_value|int) / 100) }}{% else %}(none){% endif %}</strong>
+            {% elif event.event_type == 'INCOME_NOTES_CHANGE' %}
+              <div class="small">
+                <div><span class="muted">From:</span> <span style="white-space: pre-wrap;">{{ event.old_value or '(empty)' }}</span></div>
+                <div style="margin-top: 4px;"><span class="muted">To:</span> <strong style="white-space: pre-wrap;">{{ event.new_value or '(empty)' }}</strong></div>
+              </div>
             {% elif event.snapshot %}
               {% if event.event_type == 'SUBMIT' %}
                 {{ event.snapshot.line_count }} line{% if event.snapshot.line_count != 1 %}s{% endif %}{% if event.snapshot.total_requested_cents is defined %},

--- a/app/templates/macros/comments.html
+++ b/app/templates/macros/comments.html
@@ -21,6 +21,9 @@
         {% if comment.visibility == "ADMIN" %}
           <span class="pill" style="margin-left: 4px;">Admin Only</span>
         {% endif %}
+        {% if comment.updated_at and (comment.updated_at - comment.created_at).total_seconds() > 1 %}
+          <span class="muted" style="margin-left: 4px;">(edited {% if comment.updated_at.date() == comment.created_at.date() %}{{ comment.updated_at.strftime('%H:%M') }}{% else %}{{ comment.updated_at.strftime('%Y-%m-%d %H:%M') }}{% endif %})</span>
+        {% endif %}
       </div>
       <div style="margin-top: 4px; white-space: pre-wrap;">{{ comment.body|markdown_links|safe }}</div>
     </div>

--- a/app/templates/macros/comments.html
+++ b/app/templates/macros/comments.html
@@ -22,7 +22,7 @@
           <span class="pill" style="margin-left: 4px;">Admin Only</span>
         {% endif %}
       </div>
-      <div style="margin-top: 4px; white-space: pre-wrap;">{{ comment.body }}</div>
+      <div style="margin-top: 4px; white-space: pre-wrap;">{{ comment.body|markdown_links|safe }}</div>
     </div>
   {% endfor %}
 {% else %}

--- a/migrations/versions/a7b8c9d0e1f2_add_updated_at_to_work_item_comments.py
+++ b/migrations/versions/a7b8c9d0e1f2_add_updated_at_to_work_item_comments.py
@@ -1,0 +1,51 @@
+"""Add updated_at column to work_item_comments
+
+Comments can now be edited (by author on DRAFT items, or by admins).
+The model needs an updated_at timestamp so the UI can show an "(edited)"
+indicator when a comment was modified after creation.
+
+For existing rows, backfill updated_at = created_at so the indicator stays
+hidden for legacy data. The column is added nullable first, backfilled,
+then altered to NOT NULL — standard pattern for adding a NOT NULL column
+to a table with existing rows.
+
+Revision ID: a7b8c9d0e1f2
+Revises: z6a7b8c9d0e1
+Create Date: 2026-05-17 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a7b8c9d0e1f2'
+down_revision = 'z6a7b8c9d0e1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('work_item_comments') as batch_op:
+        batch_op.add_column(sa.Column('updated_at', sa.DateTime(), nullable=True))
+
+    # Backfill existing rows so updated_at == created_at (legacy comments
+    # should not appear as "(edited)" in the UI).
+    op.execute("UPDATE work_item_comments SET updated_at = created_at")
+
+    with op.batch_alter_table('work_item_comments') as batch_op:
+        batch_op.alter_column(
+            'updated_at',
+            existing_type=sa.DateTime(),
+            nullable=False,
+        )
+        batch_op.create_index(
+            'ix_work_item_comments_updated_at',
+            ['updated_at'],
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('work_item_comments') as batch_op:
+        batch_op.drop_index('ix_work_item_comments_updated_at')
+        batch_op.drop_column('updated_at')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,19 @@
 """
 Shared pytest fixtures for the MAGFest Budget application.
 """
+import os
+
+# CRITICAL: Force tests to use in-memory SQLite BEFORE importing create_app.
+# create_app() reads DATABASE_URL via get_database_url() and immediately calls
+# db.init_app(app), which binds the SQLAlchemy engine to that URL. A later
+# config.update({"SQLALCHEMY_DATABASE_URI": ...}) inside a fixture is too late
+# — the engine is already bound to whatever URL was in env at create_app time.
+# Without this override, tests would run against the developer's local
+# instance/magfest_budget.sqlite3 and the db.drop_all() at fixture teardown
+# would wipe the dev DB. Set the env var here, before any "from app import ..."
+# fully resolves create_app's database_url lookup.
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
 import pytest
 from app import create_app, db
 from app.models import (
@@ -32,14 +45,27 @@ def app():
     """Create a Flask application configured for testing."""
     test_app = create_app()
 
-    # Override configuration for testing
+    # Override configuration for testing.
+    # NOTE: SQLALCHEMY_DATABASE_URI is intentionally NOT here — the engine
+    # is bound at db.init_app() time inside create_app(), so a config.update
+    # here would be a no-op. The DB URL is forced via DATABASE_URL env var
+    # at the top of this file, before create_app() runs.
     test_app.config.update({
         "TESTING": True,
-        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
         "WTF_CSRF_ENABLED": False,
         "DEV_LOGIN_ENABLED": False,  # Disable to avoid demo seeding issues
         "SECRET_KEY": "test-secret-key",
     })
+
+    # Defense-in-depth: never drop tables from a non-memory DB even if the
+    # env-var override above somehow fails (e.g. config gets overwritten by
+    # a future change). A wiped dev DB is a hard-to-diagnose footgun.
+    bound_uri = str(test_app.config.get("SQLALCHEMY_DATABASE_URI", ""))
+    assert ":memory:" in bound_uri, (
+        f"Test fixture refusing to operate on non-memory DB: {bound_uri!r}. "
+        f"Check that DATABASE_URL env var override at top of conftest.py is "
+        f"taking effect before create_app() runs."
+    )
 
     with test_app.app_context():
         db.create_all()

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -22,3 +22,43 @@ class TestAuthRoutes:
         assert response.status_code == 200
         # Check that the response contains expected login page content
         assert b"Sign" in response.data or b"Login" in response.data or b"sign" in response.data
+
+
+def _login(client, user_id):
+    """Set the session to simulate a logged-in user."""
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = user_id
+
+
+def test_comment_post_with_relative_return_to_redirects_to_edit_notes_tab(
+    app, client, seed_draft_work_item
+):
+    """
+    Posting a note from the edit page (with return_to=request.path, i.e. a
+    leading-slash relative path) must redirect back to the edit page with
+    tab=notes preserved. Regression test for the request.url -> request.path
+    fix in app/templates/budget/work_item_edit.html.
+
+    Note: this test asserts route behavior. It passes both before AND after
+    the template fix, because the route already handles relative paths
+    correctly. The bug was that the template was never *sending* a relative
+    path. This test is a regression guard against future drift on either
+    side.
+    """
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+    edit_path = f"/{event}/{dept}/budget/item/{item.public_id}/edit"
+
+    _login(client, "test:admin")
+
+    response = client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment",
+        data={"comment": "Test note", "return_to": edit_path},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    location = response.headers["Location"]
+    assert "/edit" in location, f"Expected redirect to edit page, got {location}"
+    assert "tab=notes" in location, f"Expected tab=notes in redirect, got {location}"

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -364,3 +364,93 @@ def test_new_comment_updated_at_equals_created_at(app, client, seed_draft_work_i
         comment = WorkItemComment.query.filter_by(work_item_id=item.id).first()
         delta_seconds = abs((comment.updated_at - comment.created_at).total_seconds())
         assert delta_seconds < 1, f"New comment should not appear edited, but delta={delta_seconds}s"
+
+
+from app.routes.admin.helpers import MAX_FREEFORM_TEXT_LENGTH as MAX_LEN
+TOO_LONG = "x" * (MAX_LEN + 1)
+
+
+def test_add_comment_over_max_length_rejected(app, client, seed_draft_work_item):
+    from app.models import WorkItemComment
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+    edit_path = f"/{event}/{dept}/budget/item/{item.public_id}/edit"
+
+    _login(client, "test:admin")
+    response = client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment",
+        data={"comment": TOO_LONG, "return_to": edit_path},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302  # flash + redirect, not 500
+    with app.app_context():
+        assert WorkItemComment.query.filter_by(work_item_id=item.id).count() == 0
+
+
+def test_edit_comment_over_max_length_rejected(app, client, seed_draft_work_item):
+    from app.models import WorkItemComment
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    with app.app_context():
+        comment = WorkItemComment(
+            work_item_id=item.id, visibility="PUBLIC",
+            body="Original", created_by_user_id="test:admin",
+        )
+        db.session.add(comment)
+        db.session.commit()
+        cid = comment.id
+
+    _login(client, "test:admin")
+    client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment/{cid}/edit",
+        data={"comment": TOO_LONG},
+    )
+    with app.app_context():
+        assert WorkItemComment.query.get(cid).body == "Original"
+
+
+def test_income_notes_over_max_length_rejected(app, client, seed_draft_work_item):
+    from app.models import WorkItem
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    _login(client, "test:admin")
+    client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/income",
+        data={"income_estimate": "", "income_notes": TOO_LONG},
+    )
+    with app.app_context():
+        assert WorkItem.query.get(item.id).income_notes in (None, "")
+
+
+def test_crlf_normalized_before_length_check(app, client, seed_draft_work_item):
+    """Browsers submit <textarea> with CRLF line endings per HTML spec.
+    Server must normalize CRLF -> LF before measuring length, otherwise
+    paragraphs falsely push a near-limit body over the cap and the user
+    sees 'too long' even though their visible character count is fine."""
+    from app.models import WorkItemComment
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+    edit_path = f"/{event}/{dept}/budget/item/{item.public_id}/edit"
+
+    # (MAX_LEN - 2) chars + 2 paragraph breaks (CRLF) = MAX_LEN + 2 raw, MAX_LEN after normalize
+    body = ("x" * (MAX_LEN - 2)) + "\r\n\r\n"
+    assert len(body) == MAX_LEN + 2
+
+    _login(client, "test:admin")
+    response = client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment",
+        data={"comment": body, "return_to": edit_path},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    with app.app_context():
+        comments = WorkItemComment.query.filter_by(work_item_id=item.id).all()
+        assert len(comments) == 1, "Body should be accepted after CRLF normalization"
+        # Body stored with LF, not CRLF
+        assert "\r" not in comments[0].body

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -1,6 +1,7 @@
 """
 Integration tests for routes using Flask test client.
 """
+from app import db
 
 
 class TestAuthRoutes:
@@ -62,3 +63,304 @@ def test_comment_post_with_relative_return_to_redirects_to_edit_notes_tab(
     location = response.headers["Location"]
     assert "/edit" in location, f"Expected redirect to edit page, got {location}"
     assert "tab=notes" in location, f"Expected tab=notes in redirect, got {location}"
+
+
+# ============================================================
+# Note (Comment) Edit/Delete + Income Audit Tests
+# ============================================================
+
+def test_author_can_edit_own_comment_on_draft_writes_audit(
+    app, client, seed_draft_work_item
+):
+    from app.models import WorkItemComment, WorkItemAuditEvent
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    with app.app_context():
+        comment = WorkItemComment(
+            work_item_id=item.id, visibility="PUBLIC",
+            body="Original text", created_by_user_id="test:admin",
+        )
+        db.session.add(comment)
+        db.session.commit()
+        comment_id = comment.id
+
+    _login(client, "test:admin")
+
+    response = client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment/{comment_id}/edit",
+        data={"comment": "Edited text"}, follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "tab=notes" in response.headers["Location"]
+
+    with app.app_context():
+        assert WorkItemComment.query.get(comment_id).body == "Edited text"
+        audits = WorkItemAuditEvent.query.filter_by(
+            work_item_id=item.id, event_type="COMMENT_EDIT"
+        ).all()
+        assert len(audits) == 1
+        assert audits[0].old_value == "Original text"
+        assert audits[0].new_value == "Edited text"
+        assert audits[0].snapshot["comment_id"] == comment_id
+
+
+def test_non_author_cannot_edit_comment(app, client, seed_draft_work_item):
+    from app.models import WorkItemComment
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    with app.app_context():
+        comment = WorkItemComment(
+            work_item_id=item.id, visibility="PUBLIC",
+            body="Original text", created_by_user_id="test:someone-else",
+        )
+        db.session.add(comment)
+        db.session.commit()
+        comment_id = comment.id
+
+    _login(client, "test:admin")
+
+    response = client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment/{comment_id}/edit",
+        data={"comment": "Hijacked"}, follow_redirects=False,
+    )
+    assert response.status_code == 403
+    with app.app_context():
+        assert WorkItemComment.query.get(comment_id).body == "Original text"
+
+
+def test_no_op_edit_writes_no_audit(app, client, seed_draft_work_item):
+    from app.models import WorkItemComment, WorkItemAuditEvent
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    with app.app_context():
+        comment = WorkItemComment(
+            work_item_id=item.id, visibility="PUBLIC",
+            body="Same text", created_by_user_id="test:admin",
+        )
+        db.session.add(comment)
+        db.session.commit()
+        comment_id = comment.id
+
+    _login(client, "test:admin")
+
+    client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment/{comment_id}/edit",
+        data={"comment": "Same text"},
+    )
+    with app.app_context():
+        assert WorkItemAuditEvent.query.filter_by(
+            work_item_id=item.id, event_type="COMMENT_EDIT"
+        ).count() == 0
+
+
+def test_author_can_delete_own_comment_writes_audit_with_body(
+    app, client, seed_draft_work_item
+):
+    from app.models import WorkItemComment, WorkItemAuditEvent
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    with app.app_context():
+        comment = WorkItemComment(
+            work_item_id=item.id, visibility="PUBLIC",
+            body="Sensitive original text", created_by_user_id="test:admin",
+        )
+        db.session.add(comment)
+        db.session.commit()
+        comment_id = comment.id
+
+    _login(client, "test:admin")
+
+    response = client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment/{comment_id}/delete",
+    )
+    assert response.status_code == 302
+    with app.app_context():
+        assert WorkItemComment.query.get(comment_id) is None
+        audits = WorkItemAuditEvent.query.filter_by(
+            work_item_id=item.id, event_type="COMMENT_DELETE"
+        ).all()
+        assert len(audits) == 1
+        assert audits[0].old_value == "Sensitive original text"
+        assert audits[0].snapshot["comment_id"] == comment_id
+
+
+def test_non_author_cannot_delete_comment(app, client, seed_draft_work_item):
+    from app.models import WorkItemComment
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    with app.app_context():
+        comment = WorkItemComment(
+            work_item_id=item.id, visibility="PUBLIC",
+            body="Original text", created_by_user_id="test:someone-else",
+        )
+        db.session.add(comment)
+        db.session.commit()
+        comment_id = comment.id
+
+    _login(client, "test:admin")
+
+    response = client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment/{comment_id}/delete",
+        follow_redirects=False,
+    )
+    assert response.status_code == 403
+    with app.app_context():
+        assert WorkItemComment.query.get(comment_id) is not None
+        assert WorkItemComment.query.get(comment_id).body == "Original text"
+
+
+def test_income_estimate_change_writes_audit(
+    app, client, seed_draft_work_item
+):
+    from app.models import WorkItemAuditEvent
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    _login(client, "test:admin")
+
+    client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/income",
+        data={"income_estimate": "100.00", "income_notes": ""},
+    )
+    with app.app_context():
+        audits = WorkItemAuditEvent.query.filter_by(
+            work_item_id=item.id, event_type="INCOME_ESTIMATE_CHANGE"
+        ).all()
+        assert len(audits) == 1
+        assert audits[0].old_value is None
+        assert audits[0].new_value == "10000"
+
+
+def test_income_notes_change_writes_audit(
+    app, client, seed_draft_work_item
+):
+    from app.models import WorkItemAuditEvent
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    _login(client, "test:admin")
+
+    client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/income",
+        data={"income_estimate": "", "income_notes": "Merch table revenue"},
+    )
+    with app.app_context():
+        audits = WorkItemAuditEvent.query.filter_by(
+            work_item_id=item.id, event_type="INCOME_NOTES_CHANGE"
+        ).all()
+        assert len(audits) == 1
+        assert audits[0].new_value == "Merch table revenue"
+
+
+def test_income_save_no_change_writes_no_audit(
+    app, client, seed_draft_work_item
+):
+    from app.models import WorkItem, WorkItemAuditEvent
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    with app.app_context():
+        wi = WorkItem.query.get(item.id)
+        wi.income_estimate_cents = 5000
+        wi.income_notes = "Existing notes"
+        db.session.commit()
+
+    _login(client, "test:admin")
+
+    client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/income",
+        data={"income_estimate": "50.00", "income_notes": "Existing notes"},
+    )
+    with app.app_context():
+        assert WorkItemAuditEvent.query.filter_by(
+            work_item_id=item.id, event_type="INCOME_ESTIMATE_CHANGE",
+        ).count() == 0
+        assert WorkItemAuditEvent.query.filter_by(
+            work_item_id=item.id, event_type="INCOME_NOTES_CHANGE",
+        ).count() == 0
+
+
+def test_adding_comment_writes_audit(app, client, seed_draft_work_item):
+    from app.models import WorkItemComment, WorkItemAuditEvent
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+    edit_path = f"/{event}/{dept}/budget/item/{item.public_id}/edit"
+
+    _login(client, "test:admin")
+    response = client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment",
+        data={"comment": "Fresh note", "return_to": edit_path},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    with app.app_context():
+        comment = WorkItemComment.query.filter_by(work_item_id=item.id).first()
+        assert comment is not None
+        audits = WorkItemAuditEvent.query.filter_by(
+            work_item_id=item.id, event_type="COMMENT_ADDED"
+        ).all()
+        assert len(audits) == 1
+        assert audits[0].new_value == "Fresh note"
+        assert audits[0].snapshot["comment_id"] == comment.id
+        assert audits[0].snapshot["visibility"] == "PUBLIC"
+
+
+def test_editing_comment_bumps_updated_at(app, client, seed_draft_work_item):
+    from app.models import WorkItemComment
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    with app.app_context():
+        comment = WorkItemComment(
+            work_item_id=item.id, visibility="PUBLIC",
+            body="v1", created_by_user_id="test:admin",
+        )
+        db.session.add(comment)
+        db.session.commit()
+        comment_id = comment.id
+        original_updated_at = comment.updated_at
+
+    import time; time.sleep(1.1)  # ensure timestamp difference > 1s tolerance
+
+    _login(client, "test:admin")
+    client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment/{comment_id}/edit",
+        data={"comment": "v2"},
+    )
+    with app.app_context():
+        updated = WorkItemComment.query.get(comment_id)
+        assert updated.updated_at > original_updated_at
+
+
+def test_new_comment_updated_at_equals_created_at(app, client, seed_draft_work_item):
+    """Brand-new comment should NOT appear as edited (updated_at ~= created_at)."""
+    from app.models import WorkItemComment
+    item = seed_draft_work_item["work_item"]
+    event = seed_draft_work_item["cycle"].code
+    dept = seed_draft_work_item["department"].code
+
+    _login(client, "test:admin")
+    client.post(
+        f"/{event}/{dept}/budget/item/{item.public_id}/comment",
+        data={"comment": "Brand new", "return_to": f"/{event}/{dept}/budget/item/{item.public_id}/edit"},
+    )
+    with app.app_context():
+        comment = WorkItemComment.query.filter_by(work_item_id=item.id).first()
+        delta_seconds = abs((comment.updated_at - comment.created_at).total_seconds())
+        assert delta_seconds < 1, f"New comment should not appear edited, but delta={delta_seconds}s"


### PR DESCRIPTION
Updated budget work item draft form

- Added character limit of 1500 for most describe boxes
- Added Edit / delete abilities for work item notes. Abilities only allowed when the budget request is in draft status
- Updated notes for description boxes to explain how to add new lines and links
- fixed the 5th tab. Now when saving page will stay on the 5th tab, and not redirect to different page on save
- Adding note (new/edit/delete) to audit log