### PR TITLE
Feature/submission confirmation email

### DIFF
--- a/app/routes/work/work_items/actions.py
+++ b/app/routes/work/work_items/actions.py
@@ -106,6 +106,20 @@ def work_item_submit(event: str, dept: str, public_id: str, work_type_slug: str 
             "Failed to send submission notification for %s", work_item.public_id
         )
 
+    # Send the BUDGET-only confirmation back to the submitting department
+    # in a separate non-blocking block so a failure here cannot roll back
+    # the admin-notification log committed above.
+    try:
+        from app.services.notifications import notify_submission_confirmation
+        notify_submission_confirmation(work_item)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        import logging
+        logging.getLogger(__name__).exception(
+            "Failed to send submission confirmation for %s", work_item.public_id
+        )
+
     flash(
         "Budget request submitted! A budget admin will assign reviewers and "
         "dispatch it for approval. You'll be notified if any changes are needed.",

--- a/app/seeds/config_seed.py
+++ b/app/seeds/config_seed.py
@@ -8,7 +8,7 @@ Composes the two layered seeds:
 Use the CLI for granular control:
     flask seed bootstrap   # only schema-required rows
     flask seed demo        # only [Demo] starter content
-    flask seed all         # both (default)
+    flask # both (default)
 
 This module is also called by the auto-seed hook in app/__init__.py
 (run_seed_once) when an empty DB is detected on first request.

--- a/app/services/email_templates.py
+++ b/app/services/email_templates.py
@@ -31,6 +31,18 @@ EMAIL_TEMPLATE_VARIABLES = {
         'work_item.portfolio.event_cycle.code': 'Event code (e.g., "MAG2027")',
         'base_url': 'Base URL of the application',
     },
+    'submission_confirmation': {
+        'work_item': 'The WorkItem just submitted (BUDGET only)',
+        'work_item.public_id': 'Public ID of the request',
+        'work_item.reason': 'Optional reason text (used by supplementals)',
+        'work_item.portfolio.department.name': 'Department name',
+        'work_item.portfolio.department.code': 'Department code',
+        'work_item.portfolio.event_cycle.name': 'Event name',
+        'work_item.portfolio.event_cycle.code': 'Event code',
+        'line_count': 'Number of budget lines on the submission',
+        'total_requested_dollars': 'Sum of unit_price * quantity across lines, in dollars (float)',
+        'base_url': 'Base URL of the application',
+    },
     'dispatched': {
         'work_item': 'The WorkItem being dispatched',
         'work_item.public_id': 'Public ID of the request',

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -68,6 +68,60 @@ def notify_work_item_submitted(work_item: WorkItem) -> int:
     return sent_count
 
 
+def notify_submission_confirmation(work_item: WorkItem) -> int:
+    """
+    Send the submitting department a confirmation that their BUDGET
+    request was received.
+
+    Audience: same dept-member set used for needs_attention / finalized
+    (direct department memberships + members of the department's
+    division), so dept leadership gets a paper trail even when a
+    deputy clicked Submit.
+
+    BUDGET-only. The 'submitted' template (which targets budget admins
+    so they can dispatch) intentionally does NOT cover this audience.
+    For non-BUDGET worktypes this function is a silent no-op so
+    submit-route callers can stay worktype-neutral.
+
+    The email body shows the requester-set line count and total — the
+    template wording explicitly frames these as "requested" so they
+    cannot be misread as an approval.
+
+    Returns: Number of emails sent.
+    """
+    portfolio = work_item.portfolio
+    work_type = portfolio.work_type if portfolio else None
+    if work_type is None or work_type.code != 'BUDGET':
+        return 0
+
+    line_count = 0
+    total_requested_cents = 0
+    for line in work_item.lines:
+        detail = line.budget_detail
+        if not detail:
+            continue
+        line_count += 1
+        total_requested_cents += int(detail.unit_price_cents * detail.quantity)
+
+    recipients = _get_department_member_emails(
+        department_id=portfolio.department_id,
+        event_cycle_id=portfolio.event_cycle_id,
+    )
+
+    return _send_emails(
+        recipients=recipients,
+        template_key='submission_confirmation',
+        work_item=work_item,
+        empty_recipients_msg=(
+            "No department member recipients found for submission_confirmation"
+        ),
+        extra_context={
+            'line_count': line_count,
+            'total_requested_dollars': total_requested_cents / 100,
+        },
+    )
+
+
 def notify_work_item_dispatched(work_item: WorkItem, approval_group_ids: List[int]) -> int:
     """
     Notify approval group members that a work item is ready for their review.
@@ -200,6 +254,7 @@ def _send_emails(
     template_key: str,
     work_item: WorkItem,
     empty_recipients_msg: str,
+    extra_context: dict | None = None,
 ) -> int:
     """
     Render a DB-backed email template and send to each recipient.
@@ -207,15 +262,23 @@ def _send_emails(
     Returns the number of emails actually sent. Logs warnings for empty
     recipient lists and errors for template-render failures, but does
     not raise — callers depend on this being non-blocking.
+
+    `extra_context` lets a caller pass template variables beyond the
+    default `work_item` / `base_url` (e.g. precomputed line totals).
+    Keys in `extra_context` win on collision.
     """
     if not recipients:
         logger.warning(f"{empty_recipients_msg}: {work_item.public_id}")
         return 0
 
-    rendered = render_email_template(template_key, {
+    context = {
         'work_item': work_item,
         'base_url': get_base_url(),
-    })
+    }
+    if extra_context:
+        context.update(extra_context)
+
+    rendered = render_email_template(template_key, context)
 
     if not rendered:
         logger.error(f"Failed to render {template_key!r} template for {work_item.public_id}")

--- a/migrations/versions/a8b9c0d1e2f3_add_submission_confirmation_template.py
+++ b/migrations/versions/a8b9c0d1e2f3_add_submission_confirmation_template.py
@@ -1,0 +1,87 @@
+"""Add submission_confirmation email template.
+
+Adds a BUDGET-only confirmation email sent to all members of the
+submitting department when a budget request transitions out of DRAFT.
+The existing 'submitted' template goes to budget admins (so they can
+dispatch); this new template tells the department itself that the
+request landed, with a line count and total requested dollars for the
+paper trail. Wording uses an explicit "requested" framing so the
+amounts are not mistaken for an approval.
+
+NOTE: Revision id deliberately skips 'z6a7b8c9d0e1' because the
+unmerged 'feature/email-system' branch already uses that id for an
+unrelated migration (scheduled_notifications). Picking a distinct id
+keeps the two branches mergeable in either order without rebasing
+the revision chain.
+
+Revision ID: a8b9c0d1e2f3
+Revises: y5z6a7b8c9d0
+Create Date: 2026-05-20
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a8b9c0d1e2f3'
+down_revision = 'y5z6a7b8c9d0'
+branch_labels = None
+depends_on = None
+
+
+TEMPLATE_KEY = 'submission_confirmation'
+
+SUBJECT = '[MAGFest Budget] Submission received - {{ work_item.public_id }}'
+
+BODY_TEXT = '''Your budget request was submitted and is waiting for a budget admin to dispatch it for review.
+
+Request: {{ work_item.public_id }}
+Department: {{ work_item.portfolio.department.name }}
+Event: {{ work_item.portfolio.event_cycle.name }}
+{% if work_item.reason %}Reason: {{ work_item.reason }}
+{% endif %}
+Submitted: {{ line_count }} line{{ 's' if line_count != 1 else '' }} totaling ${{ '%.2f'|format(total_requested_dollars) }} requested.
+
+These amounts are what your department requested — they have not been approved yet. A budget admin will dispatch the request to reviewers, and you'll get another email if any lines need your attention.
+
+View the request:
+{{ base_url }}/work/{{ work_item.portfolio.event_cycle.code }}/{{ work_item.portfolio.department.code }}/budget/item/{{ work_item.public_id }}
+'''
+
+
+def upgrade():
+    email_templates = sa.table(
+        'email_templates',
+        sa.column('template_key', sa.String),
+        sa.column('name', sa.String),
+        sa.column('description', sa.Text),
+        sa.column('subject', sa.String),
+        sa.column('body_text', sa.Text),
+        sa.column('is_active', sa.Boolean),
+        sa.column('version', sa.Integer),
+    )
+
+    op.bulk_insert(email_templates, [
+        {
+            'template_key': TEMPLATE_KEY,
+            'name': 'Budget Submission Confirmation',
+            'description': (
+                'Sent to all members of the submitting department when a BUDGET '
+                'request leaves DRAFT. Includes line count and total requested '
+                'dollars. Does not fire for non-BUDGET worktypes.'
+            ),
+            'subject': SUBJECT,
+            'body_text': BODY_TEXT,
+            'is_active': True,
+            'version': 1,
+        },
+    ])
+
+
+def downgrade():
+    op.execute(
+        sa.text("DELETE FROM email_templates WHERE template_key = :key").bindparams(
+            key=TEMPLATE_KEY
+        )
+    )

--- a/tests/integration/test_submission_confirmation.py
+++ b/tests/integration/test_submission_confirmation.py
@@ -151,3 +151,36 @@ class TestSubmissionConfirmation:
         recipients = {c.kwargs["to"] for c in send.call_args_list}
         assert "divhead@test.local" in recipients
         assert sent == len(recipients)
+
+
+class TestSubmissionConfirmationWiring:
+    """Verify the submit route actually invokes the confirmation function."""
+
+    def test_submit_route_calls_notify_submission_confirmation(
+        self, app, client, seed_draft_work_item,
+    ):
+        """
+        POSTing the submit action on a BUDGET work item triggers
+        notify_submission_confirmation alongside the existing admin
+        notification. Patching both notify calls keeps the test focused
+        on the route wiring rather than template rendering or SES.
+        """
+        with client.session_transaction() as sess:
+            sess["active_user_id"] = "test:admin"
+
+        with patch(
+            "app.services.notifications.notify_work_item_submitted",
+            return_value=1,
+        ), patch(
+            "app.services.notifications.notify_submission_confirmation",
+            return_value=2,
+        ) as confirm_mock:
+            response = client.post(
+                "/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1/submit",
+                follow_redirects=False,
+            )
+
+        assert response.status_code == 302
+        confirm_mock.assert_called_once()
+        called_work_item = confirm_mock.call_args.args[0]
+        assert called_work_item.public_id == "TST2026-TESTDEPT-BUD-1"

--- a/tests/integration/test_submission_confirmation.py
+++ b/tests/integration/test_submission_confirmation.py
@@ -1,0 +1,153 @@
+"""
+Tests for notify_submission_confirmation() — the BUDGET-only paper-trail
+email sent to the submitting department after a request leaves DRAFT.
+
+These tests exercise the audience selection, BUDGET-only gate, and
+template-context wiring at the function level. The integration test for
+the route-level wiring lives separately.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app import db
+from app.models import (
+    User,
+    Department,
+    Division,
+    DepartmentMembership,
+    DivisionMembership,
+    EmailTemplate,
+    WorkType,
+    WorkTypeConfig,
+    WorkPortfolio,
+    WorkItem,
+    WorkLine,
+    BudgetLineDetail,
+    ROUTING_STRATEGY_CATEGORY,
+    REQUEST_KIND_PRIMARY,
+    WORK_ITEM_STATUS_DRAFT,
+    WORK_LINE_STATUS_PENDING,
+    REVIEW_STAGE_APPROVAL_GROUP,
+)
+from app.services.notifications import notify_submission_confirmation
+
+
+@pytest.fixture
+def seed_submission_confirmation_template(app):
+    """
+    Seed the submission_confirmation EmailTemplate row. The test
+    conftest uses db.create_all() which builds tables from the ORM
+    but does NOT run Alembic data-seeding migrations, so any test
+    that exercises render_email_template must seed the row itself.
+    """
+    db.session.add(EmailTemplate(
+        template_key='submission_confirmation',
+        name='Budget Submission Confirmation',
+        description='test seed',
+        subject='[MAGFest Budget] Submission received - {{ work_item.public_id }}',
+        body_text=(
+            "Your budget request was submitted.\n\n"
+            "Submitted: {{ line_count }} line"
+            "{{ 's' if line_count != 1 else '' }} totaling "
+            "${{ '%.2f'|format(total_requested_dollars) }} requested.\n"
+        ),
+        is_active=True,
+        version=1,
+    ))
+    db.session.commit()
+
+
+class TestSubmissionConfirmation:
+    """Verify the BUDGET-only submission confirmation email behavior."""
+
+    def test_fires_for_budget_and_includes_line_totals(
+        self, app, seed_draft_work_item, seed_submission_confirmation_template,
+    ):
+        """
+        For a BUDGET submission, every dept member gets one email with
+        the submission_confirmation template, and the rendered context
+        carries the computed line_count + total_requested_dollars.
+        """
+        data = seed_draft_work_item
+        # Add a second dept member so we can confirm multi-recipient send.
+        member = User(
+            id="test:dept-member", email="member@test.local",
+            display_name="Dept Member", is_active=True,
+        )
+        db.session.add(member)
+        db.session.add(DepartmentMembership(
+            user_id=member.id,
+            department_id=data["department"].id,
+            event_cycle_id=data["cycle"].id,
+        ))
+        db.session.commit()
+
+        # Patch only the SES-bound send_email so we can assert call args
+        # without hitting the rate limiter / SUPPRESSED log path.
+        with patch("app.services.notifications.send_email", return_value=True) as send:
+            sent = notify_submission_confirmation(data["work_item"])
+
+        assert sent == 1
+        assert send.call_count == 1
+        call = send.call_args
+        assert call.kwargs["to"] == "member@test.local"
+        assert call.kwargs["template_key"] == "submission_confirmation"
+        # Line math: fixture has 1 line at $50 (5000 cents, qty 1).
+        assert "1 line totaling $50.00 requested" in call.kwargs["body_text"]
+
+    def test_skipped_for_non_budget_worktype(self, app, seed_draft_work_item):
+        """
+        Non-BUDGET worktypes (e.g. TECHOPS) get a silent zero — the
+        submit route stays worktype-neutral and the function gates
+        itself.
+        """
+        data = seed_draft_work_item
+        # Re-point the portfolio's work_type to a new non-BUDGET type.
+        techops_wt = WorkType(code="TECHOPS", name="TechOps", is_active=True)
+        db.session.add(techops_wt)
+        db.session.flush()
+        db.session.add(WorkTypeConfig(
+            work_type_id=techops_wt.id, url_slug="techops",
+            public_id_prefix="TOPS", line_detail_type="techops",
+            routing_strategy=ROUTING_STRATEGY_CATEGORY,
+            uses_dispatch=False, has_admin_final=False,
+        ))
+        data["portfolio"].work_type_id = techops_wt.id
+        db.session.commit()
+
+        with patch("app.services.notifications.send_email") as send:
+            sent = notify_submission_confirmation(data["work_item"])
+
+        assert sent == 0
+        send.assert_not_called()
+
+    def test_recipients_include_division_members(
+        self, app, seed_draft_work_item, seed_submission_confirmation_template,
+    ):
+        """
+        Division-membership users count as dept members for this
+        notification — same audience semantics as needs_attention /
+        finalized.
+        """
+        data = seed_draft_work_item
+        # Wire the dept into a division and add a division-only member.
+        data["department"].division_id = data["division"].id
+        div_user = User(
+            id="test:div-head", email="divhead@test.local",
+            display_name="Division Head", is_active=True,
+        )
+        db.session.add(div_user)
+        db.session.add(DivisionMembership(
+            user_id=div_user.id,
+            division_id=data["division"].id,
+            event_cycle_id=data["cycle"].id,
+        ))
+        db.session.commit()
+
+        with patch("app.services.notifications.send_email", return_value=True) as send:
+            sent = notify_submission_confirmation(data["work_item"])
+
+        recipients = {c.kwargs["to"] for c in send.call_args_list}
+        assert "divhead@test.local" in recipients
+        assert sent == len(recipients)


### PR DESCRIPTION
## Summary

  - The team reported "departments aren't getting emails when they submit a
    budget request." Investigation: the existing `notify_work_item_submitted`
    emails worktype admins (so they can dispatch) — there was no paper-trail
    email back to the submitting department. Not a bug, a missing feature.
  - Adds `notify_submission_confirmation()` — BUDGET-only, sends to the
    dept-member audience (direct memberships + division memberships, same set
    that already gets `needs_attention` / `finalized` emails), with line
    count and total **requested** dollars in the body.
  - Template wording explicitly says "requested" so the amounts cannot be
    misread as an approval before dispatch.

  ## Changes

  - **Migration `a8b9c0d1e2f3`** — seeds a new `submission_confirmation`
    `EmailTemplate` row. Revision id deliberately skips `z6a7b8c9d0e1` to
    avoid a future collision with the unmerged `feature/email-system`
    branch (which uses that id for an unrelated migration).
  - **`app/services/notifications.py`** — `notify_submission_confirmation()`
    function; `_send_emails()` gains a backward-compatible `extra_context`
    kwarg so callers can pass precomputed template variables (line count,
    total).
  - **`app/services/email_templates.py`** — documents the new template's
    variables (`line_count`, `total_requested_dollars`) for admins editing
    the wording in the UI.
  - **`app/routes/work/work_items/actions.py`** — wires the new function
    into the submit route. Kept in a separate try/except from the existing
    admin notification so a confirmation failure cannot roll back the
    admin-notification log that already committed.
  - **`tests/integration/test_submission_confirmation.py`** — 4 tests:
    fires for BUDGET, skipped for non-BUDGET, division members included,
    route invokes the function with the right work item.
