### PR TITLE
Feature/per group subtotals

### DIFF
--- a/app/routes/approvals/reviews.py
+++ b/app/routes/approvals/reviews.py
@@ -394,6 +394,12 @@ def line_respond(event: str, dept: str, public_id: str, line_num: int, work_type
             work_type_slug=work_type_slug,
         ))
 
+    # Capture the reviewer who asked for info BEFORE applying the response.
+    # apply_review_decision overwrites review.decided_by_user_id with the
+    # acting user (the responder), so reading it afterward would target the
+    # requester instead of the reviewer we mean to notify.
+    reviewer_user_id = review.decided_by_user_id
+
     # Apply the response
     success, error = apply_review_decision(
         review=review,
@@ -409,9 +415,6 @@ def line_respond(event: str, dept: str, public_id: str, line_num: int, work_type
     if not success:
         flash(error, "error")
     else:
-        # Capture reviewer before committing (may be cleared by apply_review_decision)
-        reviewer_user_id = review.decided_by_user_id
-
         flash("Response submitted. The line is back in review.", "success")
 
         # Add comment with the response
@@ -618,6 +621,12 @@ def line_adjust(event: str, dept: str, public_id: str, line_num: int, work_type_
         audit_changes.append(("description", old_description, new_description))
         detail.description = new_description or None
 
+    # Capture the reviewer who requested the adjustment BEFORE applying the
+    # response. apply_review_decision overwrites review.decided_by_user_id
+    # with the acting user (the responder), so reading it afterward would
+    # target the requester instead of the reviewer we mean to notify.
+    reviewer_user_id = review.decided_by_user_id
+
     # Apply the status transition (back to PENDING)
     success, error = apply_review_decision(
         review=review,
@@ -633,9 +642,6 @@ def line_adjust(event: str, dept: str, public_id: str, line_num: int, work_type_
     if not success:
         flash(error, "error")
     else:
-        # Capture reviewer before committing (may be cleared by apply_review_decision)
-        reviewer_user_id = review.decided_by_user_id
-
         # Create structured audit events for field changes
         if audit_changes:
             audit_line_field_changes(line, audit_changes, user_ctx)

--- a/app/routes/work/helpers/computations.py
+++ b/app/routes/work/helpers/computations.py
@@ -6,6 +6,7 @@ Functions for computing portfolio/work item totals and line status summaries.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional
 
 from app.models import (
     WorkPortfolio,
@@ -92,6 +93,60 @@ def compute_work_item_totals(item: WorkItem) -> dict:
         "approved": approved,
         "line_count": line_count,
     }
+
+
+@dataclass
+class GroupSubtotal:
+    """Per-approval-group subtotal over a set of visible lines."""
+    group_id: Optional[int]
+    group_name: str
+    line_count: int
+    requested_cents: int
+    approved_cents: int
+
+
+def compute_group_subtotals(visible_lines, group_names: dict) -> list["GroupSubtotal"]:
+    """
+    Bucket already-filtered lines by routed approval group and subtotal them.
+
+    Args:
+        visible_lines: WorkLine objects already scoped to the viewer by
+            filter_lines_for_user.
+        group_names: {approval_group_id: name} for the routed groups present.
+
+    Requested uses get_line_amount_cents (worktype-neutral). Approved sums
+    approved_amount_cents only for APPROVED lines (mirrors
+    compute_work_item_totals). Lines with a null routed group fall into a
+    single "Unassigned" bucket so subtotals reconcile to the visible total.
+
+    Returns a list ordered by group_name (case-insensitive) with the
+    Unassigned bucket last.
+    """
+    buckets: dict = {}
+    for line in visible_lines:
+        detail = line.budget_detail
+        group_id = detail.routed_approval_group_id if detail else None
+        b = buckets.setdefault(
+            group_id, {"line_count": 0, "requested": 0, "approved": 0}
+        )
+        b["line_count"] += 1
+        b["requested"] += get_line_amount_cents(line)
+        if line.status == WORK_LINE_STATUS_APPROVED:
+            b["approved"] += line.approved_amount_cents or 0
+
+    result = []
+    for group_id, b in buckets.items():
+        name = group_names.get(group_id) if group_id is not None else "Unassigned"
+        result.append(GroupSubtotal(
+            group_id=group_id,
+            group_name=name or f"Group {group_id}",
+            line_count=b["line_count"],
+            requested_cents=b["requested"],
+            approved_cents=b["approved"],
+        ))
+
+    result.sort(key=lambda g: (g.group_id is None, g.group_name.lower()))
+    return result
 
 
 # ============================================================

--- a/app/routes/work/work_items/view.py
+++ b/app/routes/work/work_items/view.py
@@ -82,6 +82,28 @@ def work_item_detail(event: str, dept: str, public_id: str, work_type_slug: str 
     )
     total_lines_count = len(all_lines)
 
+    # Per-group subtotal breakdown over the (already filtered) visible lines.
+    from app.routes.work.helpers.computations import compute_group_subtotals
+    from app.models import ApprovalGroup
+
+    routed_ids = {
+        line.budget_detail.routed_approval_group_id
+        for line in lines
+        if line.budget_detail and line.budget_detail.routed_approval_group_id
+    }
+    group_names = {}
+    if routed_ids:
+        for ag in ApprovalGroup.query.filter(ApprovalGroup.id.in_(routed_ids)).all():
+            group_names[ag.id] = ag.name
+
+    group_subtotals = compute_group_subtotals(lines, group_names)
+    distinct_group_count = sum(1 for g in group_subtotals if g.group_id is not None)
+    show_group_breakdown = distinct_group_count > 0 and (
+        lines_filtered or distinct_group_count >= 2
+    )
+    visible_requested_cents = sum(g.requested_cents for g in group_subtotals)
+    visible_approved_cents = sum(g.approved_cents for g in group_subtotals)
+
     # Get kicked-back lines (NEEDS_INFO or NEEDS_ADJUSTMENT) with their review notes
     kicked_back_lines = get_kicked_back_lines_summary(lines)
 
@@ -114,6 +136,10 @@ def work_item_detail(event: str, dept: str, public_id: str, work_type_slug: str 
         totals=totals,
         total_lines_count=total_lines_count,
         lines_filtered=lines_filtered,
+        group_subtotals=group_subtotals,
+        show_group_breakdown=show_group_breakdown,
+        visible_requested_cents=visible_requested_cents,
+        visible_approved_cents=visible_approved_cents,
         format_currency=format_currency,
         friendly_status=friendly_status,
         kicked_back_lines=kicked_back_lines,

--- a/app/templates/budget/_work_item_lines_table.html
+++ b/app/templates/budget/_work_item_lines_table.html
@@ -117,8 +117,42 @@
       {% endfor %}
     </tbody>
     <tfoot>
+      {% if show_group_breakdown %}
+        {% for g in group_subtotals %}
+          <tr class="muted">
+            <td colspan="5" class="right">{{ g.group_name }} ({{ g.line_count }} line{% if g.line_count != 1 %}s{% endif %}):</td>
+            <td class="right num">{{ format_currency(g.requested_cents) }}</td>
+            {% if show_approved_column %}
+              <td class="right num">{{ format_currency(g.approved_cents) }}</td>
+            {% endif %}
+            <td></td>
+            {% if status == "SUBMITTED" or status == "UNDER_REVIEW" or status == "NEEDS_INFO" %}
+              <td></td>
+            {% endif %}
+          </tr>
+        {% endfor %}
+        {% if lines_filtered %}
+          <tr style="font-weight: 700;">
+            <td colspan="5" class="right">Your total ({{ lines|length }} line{% if lines|length != 1 %}s{% endif %}):</td>
+            <td class="right num">{{ format_currency(visible_requested_cents) }}</td>
+            {% if show_approved_column %}
+              <td class="right num" style="color: #059669;">{{ format_currency(visible_approved_cents) }}</td>
+            {% endif %}
+            <td></td>
+            {% if status == "SUBMITTED" or status == "UNDER_REVIEW" or status == "NEEDS_INFO" %}
+              <td></td>
+            {% endif %}
+          </tr>
+        {% endif %}
+      {% endif %}
       <tr style="font-weight: 700;">
-        <td colspan="5" class="right">Grand Total Requested:</td>
+        <td colspan="5" class="right">
+          {% if lines_filtered %}
+            Full request total: <span class="muted small" style="font-weight: 400;">(incl. lines for other groups)</span>
+          {% else %}
+            Grand Total Requested:
+          {% endif %}
+        </td>
         <td class="right num">{{ format_currency(totals.requested) }}</td>
         {% if show_approved_column %}
           <td class="right num" style="color: #059669;">{{ format_currency(totals.approved) }}</td>

--- a/app/templates/budget/work_item_detail.html
+++ b/app/templates/budget/work_item_detail.html
@@ -53,6 +53,7 @@
       {% if lines_filtered %}
         <div class="muted small" style="margin-top: 4px; color: #0a66c2;">
           Showing {{ lines|length }} line{% if lines|length != 1 %}s{% endif %} for your reviewer group
+          {%- if visible_requested_cents %} &middot; your total {{ format_currency(visible_requested_cents) }}{% endif %}
         </div>
       {% endif %}
       {% if totals.approved > 0 %}

--- a/tests/integration/test_group_subtotals_view.py
+++ b/tests/integration/test_group_subtotals_view.py
@@ -3,7 +3,8 @@ from app import db
 from app.models import (
     WorkItem, WorkLine, BudgetLineDetail, ApprovalGroup, UserRole,
     REQUEST_KIND_PRIMARY, WORK_ITEM_STATUS_SUBMITTED,
-    WORK_LINE_STATUS_PENDING, REVIEW_STAGE_APPROVAL_GROUP, ROLE_APPROVER,
+    WORK_LINE_STATUS_PENDING, WORK_LINE_STATUS_APPROVED,
+    REVIEW_STAGE_APPROVAL_GROUP, ROLE_APPROVER,
 )
 
 
@@ -141,3 +142,78 @@ def test_predispatch_unrouted_lines_have_no_breakdown(app, client, seed_workflow
 
     assert "Unassigned (" not in html
     assert "Grand Total Requested:" in html
+
+
+def test_multi_group_reviewer_sees_each_group_and_combined_total(app, client, seed_workflow_data):
+    data = seed_workflow_data
+    tech = data["approval_group"]           # "Tech Team"
+    hotel = _second_group(data)
+    # Third, hidden group the reviewer does NOT belong to.
+    av = ApprovalGroup(
+        work_type_id=data["work_type"].id,
+        code="AV", name="AV Team", is_active=True,
+    )
+    db.session.add(av)
+    db.session.commit()
+
+    _make_multi_group_item(data, [
+        (tech.id, 200_00, 2),    # 400.00 - visible (reviewer's group)
+        (hotel.id, 100_00, 3),   # 300.00 - visible (reviewer's group)
+        (av.id, 50_00, 1),       # 50.00  - hidden
+    ])
+    # Reviewer is an APPROVER for BOTH tech and hotel.
+    db.session.add(UserRole(
+        user_id=data["reviewer"].id, role_code=ROLE_APPROVER,
+        approval_group_id=tech.id,
+    ))
+    db.session.add(UserRole(
+        user_id=data["reviewer"].id, role_code=ROLE_APPROVER,
+        approval_group_id=hotel.id,
+    ))
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:reviewer"
+
+    resp = client.get("/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Tech Team (" in html
+    assert "Hotel Team (" in html
+    assert "AV Team (" not in html               # hidden group not in breakdown
+    assert "Your total (2 lines):" in html
+    assert "$700.00" in html                     # combined visible total (400 + 300)
+    assert "$400.00" in html                     # tech-only subtotal, differs from combined
+    assert "$300.00" in html                     # hotel-only subtotal, differs from combined
+    assert "Full request total:" in html         # relabeled for filtered view
+    assert "Grand Total Requested:" not in html
+    assert "$750.00" in html                      # full request total (400 + 300 + 50)
+
+
+def test_approved_subtotals_render_when_approved_column_shown(app, client, seed_workflow_data):
+    data = seed_workflow_data
+    tech = data["approval_group"]
+    hotel = _second_group(data)
+    work_item = _make_multi_group_item(data, [
+        (tech.id, 200_00, 2),   # 400.00
+        (hotel.id, 100_00, 3),  # 300.00
+    ])
+
+    tech_line = WorkLine.query.filter_by(
+        work_item_id=work_item.id, line_number=1,
+    ).first()
+    tech_line.status = WORK_LINE_STATUS_APPROVED
+    tech_line.approved_amount_cents = 350_00
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:admin"   # SUPER_ADMIN
+
+    resp = client.get("/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Tech Team (" in html
+    assert "Hotel Team (" in html
+    assert "$350.00" in html                     # approved subtotal for the TECH group

--- a/tests/integration/test_group_subtotals_view.py
+++ b/tests/integration/test_group_subtotals_view.py
@@ -1,0 +1,143 @@
+"""Integration tests: per-group subtotal breakdown on the detail view."""
+from app import db
+from app.models import (
+    WorkItem, WorkLine, BudgetLineDetail, ApprovalGroup, UserRole,
+    REQUEST_KIND_PRIMARY, WORK_ITEM_STATUS_SUBMITTED,
+    WORK_LINE_STATUS_PENDING, REVIEW_STAGE_APPROVAL_GROUP, ROLE_APPROVER,
+)
+
+
+def _make_multi_group_item(data, routing):
+    """Create a SUBMITTED work item with one line per entry in `routing`.
+
+    routing: list of (approval_group_id_or_None, unit_price_cents, quantity).
+    Returns the WorkItem.
+    """
+    work_item = WorkItem(
+        portfolio_id=data["portfolio"].id,
+        request_kind=REQUEST_KIND_PRIMARY,
+        status=WORK_ITEM_STATUS_SUBMITTED,
+        public_id="TST2026-TESTDEPT-BUD-1",
+        created_by_user_id=data["admin"].id,
+    )
+    db.session.add(work_item)
+    db.session.flush()
+
+    for idx, (group_id, price, qty) in enumerate(routing, start=1):
+        line = WorkLine(
+            work_item_id=work_item.id, line_number=idx,
+            status=WORK_LINE_STATUS_PENDING,
+            current_review_stage=REVIEW_STAGE_APPROVAL_GROUP,
+        )
+        db.session.add(line)
+        db.session.flush()
+        db.session.add(BudgetLineDetail(
+            work_line_id=line.id,
+            expense_account_id=data["expense_account"].id,
+            spend_type_id=data["spend_type"].id,
+            quantity=qty, unit_price_cents=price,
+            routed_approval_group_id=group_id,
+        ))
+    db.session.commit()
+    return work_item
+
+
+def _second_group(data):
+    """Create and return a second approval group (HOTEL)."""
+    ag = ApprovalGroup(
+        work_type_id=data["work_type"].id,
+        code="HOTEL", name="Hotel Team", is_active=True,
+    )
+    db.session.add(ag)
+    db.session.commit()
+    return ag
+
+
+def test_reviewer_sees_their_group_subtotal_and_relabeled_grand_total(app, client, seed_workflow_data):
+    data = seed_workflow_data
+    tech = data["approval_group"]           # "Tech Team"
+    hotel = _second_group(data)
+    # 2 lines routed to TECH (reviewer's group), 1 to HOTEL (hidden).
+    _make_multi_group_item(data, [
+        (tech.id, 200_00, 2),   # 400.00
+        (tech.id, 100_00, 1),   # 100.00
+        (hotel.id, 50_00, 3),   # 150.00 — not visible to this reviewer
+    ])
+    # Make the reviewer an APPROVER for TECH only.
+    db.session.add(UserRole(
+        user_id=data["reviewer"].id, role_code=ROLE_APPROVER,
+        approval_group_id=tech.id,
+    ))
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:reviewer"
+
+    resp = client.get("/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Your total (2 lines):" in html
+    assert "$500.00" in html               # TECH subtotal / your total
+    assert "Full request total:" in html   # relabeled for filtered view
+    assert "$650.00" in html               # full request total (500 + 150)
+    assert "Grand Total Requested:" not in html
+
+
+def test_admin_sees_all_group_subtotals_no_your_total(app, client, seed_workflow_data):
+    data = seed_workflow_data
+    tech = data["approval_group"]
+    hotel = _second_group(data)
+    _make_multi_group_item(data, [
+        (tech.id, 200_00, 2),   # 400.00
+        (hotel.id, 50_00, 3),   # 150.00
+    ])
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:admin"   # SUPER_ADMIN
+
+    resp = client.get("/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Tech Team (1 line):" in html
+    assert "Hotel Team (1 line):" in html
+    assert "Your total" not in html                 # admin view, not filtered
+    assert "Grand Total Requested:" in html         # admin keeps original label
+
+
+def test_single_group_admin_request_has_no_breakdown(app, client, seed_workflow_data):
+    data = seed_workflow_data
+    tech = data["approval_group"]
+    _make_multi_group_item(data, [
+        (tech.id, 200_00, 2),
+        (tech.id, 100_00, 1),
+    ])
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:admin"
+
+    resp = client.get("/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Tech Team (" not in html                # breakdown suppressed
+    assert "Grand Total Requested:" in html
+
+
+def test_predispatch_unrouted_lines_have_no_breakdown(app, client, seed_workflow_data):
+    data = seed_workflow_data
+    _make_multi_group_item(data, [
+        (None, 200_00, 2),
+        (None, 100_00, 1),
+    ])
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:admin"
+
+    resp = client.get("/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Unassigned (" not in html
+    assert "Grand Total Requested:" in html

--- a/tests/integration/test_response_notification_recipient.py
+++ b/tests/integration/test_response_notification_recipient.py
@@ -1,0 +1,101 @@
+"""
+Regression guard for the line-level requester-response notification.
+
+When a requester responds to a NEEDS_INFO line, the reviewer who asked
+for the info must be the one notified. This is subtle because
+apply_review_decision unconditionally overwrites review.decided_by_user_id
+with the acting user (app/routes/approvals/helpers.py:573):
+
+    review.decided_by_user_id = user_ctx.user_id
+
+For a RESPOND action user_ctx is the *responder*, so line_respond must
+capture review.decided_by_user_id BEFORE calling apply_review_decision.
+A prior version read it afterward, which sent the "a response arrived"
+notification to the responder instead of the reviewer — the reviewer
+never learned a response came in. See app/routes/approvals/reviews.py
+(line_respond / line_adjust) and notify_response_received in
+app/services/notifications.py.
+
+This test drives the real HTTP route and asserts the original reviewer
+is the id handed to notify_response_received. If the capture order
+regresses, it fails.
+"""
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+from app import db
+from app.models import (
+    WorkItem,
+    WorkLineReview,
+    REVIEW_STAGE_APPROVAL_GROUP,
+    REVIEW_STATUS_NEEDS_INFO,
+    WORK_ITEM_STATUS_SUBMITTED,
+    WORK_LINE_STATUS_NEEDS_INFO,
+)
+
+
+def test_response_notifies_original_reviewer_not_responder(app, client, seed_draft_work_item):
+    """
+    Reviewer test:reviewer flags line 1 NEEDS_INFO; super-admin test:admin
+    (a *different* user with rights) responds. The response_received
+    notification should target the original reviewer, not the responder.
+    """
+    data = seed_draft_work_item
+    reviewer_id = data["reviewer"].id       # "test:reviewer" — asked for info
+    responder_id = data["admin"].id         # "test:admin"    — SUPER_ADMIN, responds
+
+    # --- Arrange: put line 1 into NEEDS_INFO, decided by the reviewer ---
+    with app.app_context():
+        work_item = WorkItem.query.filter_by(
+            public_id="TST2026-TESTDEPT-BUD-1"
+        ).one()
+        work_item.status = WORK_ITEM_STATUS_SUBMITTED
+
+        line = work_item.lines[0]
+        line.status = WORK_LINE_STATUS_NEEDS_INFO
+        line.needs_requester_action = True
+
+        review = WorkLineReview(
+            work_line_id=line.id,
+            stage=REVIEW_STAGE_APPROVAL_GROUP,
+            approval_group_id=data["approval_group"].id,   # matches routed group
+            status=REVIEW_STATUS_NEEDS_INFO,
+            note="Please clarify the vendor.",
+            decided_at=datetime.utcnow(),
+            decided_by_user_id=reviewer_id,
+            created_by_user_id=reviewer_id,
+        )
+        db.session.add(review)
+        db.session.commit()
+
+    # Log in as the responder (distinct from the reviewer).
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = responder_id
+
+    # --- Act: respond, capturing the id passed to the notifier ---
+    fake_notify = MagicMock(return_value=True)
+    with patch(
+        "app.services.notifications.notify_response_received",
+        fake_notify,
+    ):
+        response = client.post(
+            "/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1/line/1/respond",
+            data={"response": "The vendor is ACME Supplies."},
+            follow_redirects=False,
+        )
+
+    # The response itself must succeed regardless of the bug.
+    assert response.status_code == 302
+
+    # The notifier must have been invoked exactly once.
+    fake_notify.assert_called_once()
+
+    # Second positional arg is reviewer_user_id (work_item, reviewer_user_id).
+    notified_user_id = fake_notify.call_args.args[1]
+
+    assert notified_user_id == reviewer_id, (
+        f"Expected the original reviewer ({reviewer_id!r}) to be notified, "
+        f"but notify_response_received was called with {notified_user_id!r} "
+        f"(the responder). The reviewer never learns a response arrived — "
+        f"they must watch the Slack channel instead."
+    )

--- a/tests/unit/test_group_subtotals.py
+++ b/tests/unit/test_group_subtotals.py
@@ -1,0 +1,67 @@
+"""Unit tests for compute_group_subtotals."""
+from types import SimpleNamespace
+
+from app.routes.work.helpers.computations import (
+    compute_group_subtotals,
+    GroupSubtotal,
+)
+
+
+def _line(group_id, unit_price_cents, quantity, status="PENDING", approved_cents=None):
+    """Build a minimal WorkLine-like stub for the helper.
+
+    The helper reads line.budget_detail.routed_approval_group_id,
+    line.status, line.approved_amount_cents, and (via get_line_amount_cents)
+    budget_detail.unit_price_cents / quantity.
+    """
+    detail = SimpleNamespace(
+        routed_approval_group_id=group_id,
+        unit_price_cents=unit_price_cents,
+        quantity=quantity,
+    )
+    return SimpleNamespace(
+        budget_detail=detail,
+        contract_detail=None,
+        supply_detail=None,
+        techops_detail=None,
+        status=status,
+        approved_amount_cents=approved_cents,
+    )
+
+
+def test_buckets_by_group_with_requested_and_approved():
+    lines = [
+        _line(1, 200_00, 2, status="APPROVED", approved_cents=350_00),  # req 400.00, appr 350.00
+        _line(1, 100_00, 1),                                            # req 100.00, appr 0
+        _line(2, 50_00, 3, status="APPROVED", approved_cents=150_00),   # req 150.00, appr 150.00
+    ]
+    group_names = {1: "TECH", 2: "HOTEL"}
+
+    result = compute_group_subtotals(lines, group_names)
+
+    assert [g.group_name for g in result] == ["HOTEL", "TECH"]  # alpha order
+    hotel = next(g for g in result if g.group_id == 2)
+    tech = next(g for g in result if g.group_id == 1)
+    assert tech.line_count == 2
+    assert tech.requested_cents == 500_00
+    assert tech.approved_cents == 350_00
+    assert hotel.line_count == 1
+    assert hotel.requested_cents == 150_00
+    assert hotel.approved_cents == 150_00
+
+
+def test_null_group_becomes_unassigned_and_sorts_last():
+    lines = [
+        _line(None, 100_00, 1),
+        _line(1, 100_00, 1),
+    ]
+    result = compute_group_subtotals(lines, {1: "TECH"})
+
+    assert [g.group_name for g in result] == ["TECH", "Unassigned"]
+    unassigned = result[-1]
+    assert unassigned.group_id is None
+    assert unassigned.requested_cents == 100_00
+
+
+def test_empty_lines_returns_empty_list():
+    assert compute_group_subtotals([], {}) == []


### PR DESCRIPTION
Summary
  
  Adds a per-approval-group subtotal breakdown to the budget work-item detail totals footer, so
  reviewers see their group's slice without adding up lines by hand, and budget admins see the shape of
  a multi-group request.
  
  - New compute_group_subtotals helper buckets the already-filtered visible lines by their
  routed_approval_group_id snapshot and returns per-group Requested + Approved subtotals (integer
  cents).
  - The detail-view footer renders one subtotal row per group present. Reviewers also get a bold "Your 
  total (N lines)" row, and the grand total is relabeled "Full request total … (incl. lines for other 
  groups)"; the header caption gains "· your total $X".
  - The breakdown appears only when lines are dispatched and the view is filtered (reviewer) or the
  request spans ≥2 groups — single-group admin requests and pre-dispatch views render exactly as before.
  - Admins see every group the request spans; no "Your total" row, original "Grand Total Requested"
  label kept.

The first commit (e68563a) accidentally bundles an unrelated bug fix under the helper commit message:
  
  - app/routes/approvals/reviews.py — capture the reviewer's id before apply_review_decision overwrites
  review.decided_by_user_id, so the response_received notification reaches the reviewer who asked, not
  the responder. Fixes both line_respond (NEEDS_INFO) and line_adjust (NEEDS_ADJUSTMENT).
  - tests/integration/test_response_notification_recipient.py — regression test.