### PR TITLE
Feature/budget admin line tools

### DIFF
--- a/app/routes/admin_final/__init__.py
+++ b/app/routes/admin_final/__init__.py
@@ -19,3 +19,4 @@ from . import expense_account_report
 from . import reviewer_group_report
 from . import hotel_rooms_report
 from . import warehouse_report
+from . import line_admin

--- a/app/routes/admin_final/helpers.py
+++ b/app/routes/admin_final/helpers.py
@@ -16,6 +16,7 @@ from app.models import (
     WorkItem,
     WorkLine,
     WorkLineReview,
+    WorkLineComment,
     WorkItemAuditEvent,
     WorkLineAuditEvent,
     WorkPortfolio,
@@ -23,6 +24,7 @@ from app.models import (
     EventCycle,
     Department,
     ExpenseAccount,
+    SpendType,
     ApprovalGroup,
     REVIEW_STAGE_APPROVAL_GROUP,
     REVIEW_STAGE_ADMIN_FINAL,
@@ -35,6 +37,7 @@ from app.models import (
     WORK_ITEM_STATUS_SUBMITTED,
     WORK_ITEM_STATUS_FINALIZED,
     WORK_ITEM_STATUS_PAUSED,
+    WORK_ITEM_STATUS_NEEDS_INFO,
     WORK_LINE_STATUS_PENDING,
     WORK_LINE_STATUS_NEEDS_INFO,
     WORK_LINE_STATUS_NEEDS_ADJUSTMENT,
@@ -50,6 +53,7 @@ from app.models import (
     REVIEW_ACTION_RESET,
     REQUEST_KIND_PRIMARY,
     REQUEST_KIND_SUPPLEMENTARY,
+    COMMENT_VISIBILITY_PUBLIC,
 )
 from app.routes import UserContext
 from app.routes.work.helpers.checkout import is_checked_out
@@ -698,6 +702,95 @@ def reset_line_for_rereview(
         "Reset for re-review",
         user_ctx,
     )
+
+    return True, None
+
+
+# ============================================================
+# Admin Line Tools (account correction / add line)
+# ============================================================
+
+def change_line_expense_account(
+    line: WorkLine,
+    work_item: WorkItem,
+    new_account: "ExpenseAccount",
+    new_spend_type: "SpendType",
+    new_group: "ApprovalGroup",
+    note: str,
+    user_ctx: UserContext,
+) -> Tuple[bool, Optional[str]]:
+    """
+    Admin-only correction: move a line to a different expense account and
+    kick it back to an explicitly chosen approval group for re-review.
+
+    Resets the line + both review stages to PENDING (nothing is deleted:
+    comments and audit history survive; the reset itself is audited).
+    Does not commit — caller commits.
+    """
+    require_budget_admin(user_ctx)
+
+    if work_item.status not in (WORK_ITEM_STATUS_SUBMITTED, WORK_ITEM_STATUS_NEEDS_INFO):
+        return False, "Expense account can only be changed while the request is under review."
+
+    if is_checked_out(work_item):
+        return False, (
+            "Cannot change expense account: a reviewer has this request "
+            "checked out. Release the checkout first."
+        )
+
+    detail = line.budget_detail
+    if not detail:
+        return False, "This line has no budget details."
+
+    if not (note or "").strip():
+        return False, "A note explaining this change is required."
+
+    old_account_name = detail.expense_account.name if detail.expense_account else str(detail.expense_account_id)
+    old_spend_type_name = detail.spend_type.name if detail.spend_type else str(detail.spend_type_id)
+    old_group_name = detail.routed_approval_group.name if detail.routed_approval_group else "Unassigned"
+
+    detail.expense_account_id = new_account.id
+    detail.spend_type_id = new_spend_type.id
+    detail.routed_approval_group_id = new_group.id
+
+    ag_review = get_approval_group_review(line)
+    if ag_review:
+        ag_review.status = REVIEW_STATUS_PENDING
+        ag_review.approval_group_id = new_group.id
+        ag_review.approved_amount_cents = None
+        ag_review.decided_at = None
+        ag_review.decided_by_user_id = None
+        ag_review.note = None
+    else:
+        # Defensive: SUBMITTED items get AG reviews at dispatch, but never
+        # let a line exist in review without one (finalize would auto-approve it).
+        ag_review = WorkLineReview(
+            work_line_id=line.id,
+            stage=REVIEW_STAGE_APPROVAL_GROUP,
+            approval_group_id=new_group.id,
+            status=REVIEW_STATUS_PENDING,
+            created_by_user_id=user_ctx.user_id,
+        )
+        db.session.add(ag_review)
+
+    # Resets line status/approved amount + ADMIN_FINAL review, writes reset audit
+    reset_line_for_rereview(line, user_ctx)
+    line.current_review_stage = REVIEW_STAGE_APPROVAL_GROUP
+
+    from app.routes.approvals.helpers import audit_line_field_changes
+    changes = [("expense_account", old_account_name, new_account.name)]
+    if old_spend_type_name != new_spend_type.name:
+        changes.append(("spend_type", old_spend_type_name, new_spend_type.name))
+    if old_group_name != new_group.name:
+        changes.append(("review_group", old_group_name, new_group.name))
+    audit_line_field_changes(line, changes, user_ctx)
+
+    db.session.add(WorkLineComment(
+        work_line_id=line.id,
+        visibility=COMMENT_VISIBILITY_PUBLIC,
+        body=f"[ADMIN ACCOUNT CHANGE] {note.strip()}",
+        created_by_user_id=user_ctx.user_id,
+    ))
 
     return True, None
 

--- a/app/routes/admin_final/helpers.py
+++ b/app/routes/admin_final/helpers.py
@@ -795,6 +795,90 @@ def change_line_expense_account(
     return True, None
 
 
+def admin_add_line(
+    work_item: WorkItem,
+    user_ctx: UserContext,
+    *,
+    expense_account: "ExpenseAccount",
+    spend_type: "SpendType",
+    approval_group: "ApprovalGroup",
+    quantity,
+    unit_price_cents: int,
+    confidence_level,
+    frequency,
+    priority,
+    warehouse_flag: bool,
+    description: str,
+    note: str,
+) -> Tuple[Optional[WorkLine], Optional[str]]:
+    """
+    Admin-only: add a new line to an in-review work item, fully routed
+    (snapshot + PENDING approval-group review) so finalize can never
+    auto-approve it without a reviewer having had the chance to see it.
+    Does not commit — caller commits.
+    """
+    require_budget_admin(user_ctx)
+
+    if work_item.status not in (WORK_ITEM_STATUS_SUBMITTED, WORK_ITEM_STATUS_NEEDS_INFO):
+        return None, "Lines can only be added while the request is under review."
+
+    if is_checked_out(work_item):
+        return None, (
+            "Cannot add a line: a reviewer has this request checked out. "
+            "Release the checkout first."
+        )
+
+    if not (note or "").strip():
+        return None, "A note explaining this addition is required."
+
+    from app.routes.work.helpers.formatting import get_next_line_number
+    line = WorkLine(
+        work_item_id=work_item.id,
+        line_number=get_next_line_number(work_item),
+        status=WORK_LINE_STATUS_PENDING,
+        current_review_stage=REVIEW_STAGE_APPROVAL_GROUP,
+        updated_by_user_id=user_ctx.user_id,
+    )
+    db.session.add(line)
+    db.session.flush()
+
+    detail = BudgetLineDetail(
+        work_line_id=line.id,
+        expense_account_id=expense_account.id,
+        spend_type_id=spend_type.id,
+        unit_price_cents=unit_price_cents,
+        quantity=quantity,
+        confidence_level_id=confidence_level.id,
+        frequency_id=frequency.id,
+        priority_id=priority.id,
+        warehouse_flag=warehouse_flag,
+        description=description,
+        routed_approval_group_id=approval_group.id,
+    )
+    db.session.add(detail)
+    db.session.flush()
+
+    db.session.add(WorkLineReview(
+        work_line_id=line.id,
+        stage=REVIEW_STAGE_APPROVAL_GROUP,
+        approval_group_id=approval_group.id,
+        status=REVIEW_STATUS_PENDING,
+        created_by_user_id=user_ctx.user_id,
+    ))
+
+    from app.routes.approvals.helpers import audit_line_created
+    audit_line_created(line, detail, user_ctx)
+
+    db.session.add(WorkLineComment(
+        work_line_id=line.id,
+        visibility=COMMENT_VISIBILITY_PUBLIC,
+        body=f"[ADMIN LINE ADDED] {note.strip()}",
+        created_by_user_id=user_ctx.user_id,
+    ))
+
+    return line, None
+
+
 # ============================================================
 # Dashboard Queues
 # ============================================================

--- a/app/routes/admin_final/helpers.py
+++ b/app/routes/admin_final/helpers.py
@@ -732,9 +732,11 @@ def change_line_expense_account(
     if work_item.status not in (WORK_ITEM_STATUS_SUBMITTED, WORK_ITEM_STATUS_NEEDS_INFO):
         return False, "Expense account can only be changed while the request is under review."
 
-    if is_checked_out(work_item):
+    # An admin's own checkout doesn't block — the guard protects a
+    # *different* reviewer from the line changing under them mid-review.
+    if is_checked_out(work_item) and work_item.checked_out_by_user_id != user_ctx.user_id:
         return False, (
-            "Cannot change expense account: a reviewer has this request "
+            "Cannot change expense account: another reviewer has this request "
             "checked out. Release the checkout first."
         )
 
@@ -822,9 +824,10 @@ def admin_add_line(
     if work_item.status not in (WORK_ITEM_STATUS_SUBMITTED, WORK_ITEM_STATUS_NEEDS_INFO):
         return None, "Lines can only be added while the request is under review."
 
-    if is_checked_out(work_item):
+    # An admin's own checkout doesn't block — see change_line_expense_account.
+    if is_checked_out(work_item) and work_item.checked_out_by_user_id != user_ctx.user_id:
         return None, (
-            "Cannot add a line: a reviewer has this request checked out. "
+            "Cannot add a line: another reviewer has this request checked out. "
             "Release the checkout first."
         )
 

--- a/app/routes/admin_final/line_admin.py
+++ b/app/routes/admin_final/line_admin.py
@@ -204,3 +204,154 @@ def line_change_account_submit(event: str, dept: str, public_id: str, line_num: 
         "admin_final.line_review",
         event=event, dept=dept, public_id=public_id, line_num=line_num,
     ))
+
+
+# ============================================================
+# Admin Add Line
+# ============================================================
+
+def _parse_line_numbers(form):
+    """
+    Validate quantity / unit_price / confidence / frequency / priority /
+    warehouse / description. Mirrors app/routes/work/lines.py:237-294.
+    Returns (values_dict, errors).
+    """
+    errors = []
+    values = {}
+
+    quantity = Decimal("1")
+    quantity_str = (form.get("quantity") or "1").strip()
+    if quantity_str:
+        try:
+            quantity = Decimal(quantity_str)
+            if quantity <= 0:
+                errors.append("Quantity must be greater than 0.")
+        except InvalidOperation:
+            errors.append("Invalid quantity value.")
+    values["quantity"] = quantity
+
+    unit_price_cents = 0
+    unit_price_str = (form.get("unit_price") or "0").strip()
+    if unit_price_str:
+        try:
+            unit_price_dollars = Decimal(unit_price_str)
+            if unit_price_dollars < 0:
+                errors.append("Unit price cannot be negative.")
+            else:
+                unit_price_cents = int(unit_price_dollars * 100)
+        except InvalidOperation:
+            errors.append("Invalid unit price value.")
+    values["unit_price_cents"] = unit_price_cents
+
+    for field, model, label in (
+        ("confidence_level_id", ConfidenceLevel, "Confidence level"),
+        ("frequency_id", FrequencyOption, "Frequency"),
+        ("priority_id", PriorityLevel, "Priority"),
+    ):
+        obj = None
+        id_str = (form.get(field) or "").strip()
+        if not id_str:
+            errors.append(f"{label} is required.")
+        else:
+            try:
+                obj = model.query.get(int(id_str))
+            except ValueError:
+                obj = None
+            if not obj or not obj.is_active:
+                errors.append(f"Invalid {label.lower()}.")
+                obj = None
+        values[field.replace("_id", "")] = obj
+
+    values["warehouse_flag"] = form.get("warehouse_flag") == "on"
+
+    from app.routes.admin.helpers import MAX_FREEFORM_TEXT_LENGTH
+    description_raw = (form.get("description") or "").replace("\r\n", "\n").replace("\r", "\n")
+    if len(description_raw) > MAX_FREEFORM_TEXT_LENGTH:
+        errors.append(f"Line description is too long (max {MAX_FREEFORM_TEXT_LENGTH:,} characters).")
+    values["description"] = description_raw.strip()
+
+    return values, errors
+
+
+def _get_work_item_for_add(event, dept, public_id, work_type_slug):
+    from app.routes.work.helpers import get_portfolio_context, require_budget_work_type
+    from app.models import WorkItem
+    ctx = get_portfolio_context(event, dept, work_type_slug)
+    require_budget_work_type(ctx)
+    work_item = WorkItem.query.filter_by(
+        public_id=public_id, portfolio_id=ctx.portfolio.id, is_archived=False,
+    ).first()
+    if not work_item:
+        abort(404, f"Work item not found: {public_id}")
+    return work_item, ctx
+
+
+@admin_final_bp.get("/<event>/<dept>/<work_type_slug>/item/<public_id>/add-line")
+@admin_final_bp.get("/<event>/<dept>/budget/item/<public_id>/add-line")
+def line_add(event: str, dept: str, public_id: str, work_type_slug: str = "budget"):
+    """Form: admin adds a new line to an in-review request."""
+    user_ctx = get_user_ctx()
+    require_budget_admin(user_ctx)
+    work_item, ctx = _get_work_item_for_add(event, dept, public_id, work_type_slug)
+
+    expense_accounts = _get_admin_expense_accounts(ctx.event_cycle.id)
+    from app.routes.work.lines import build_spend_types_by_account
+    return render_template(
+        "admin_final/line_add.html",
+        ctx=ctx,
+        work_item=work_item,
+        expense_accounts=expense_accounts,
+        spend_types_by_account=build_spend_types_by_account(expense_accounts),
+        approval_groups=_get_budget_approval_groups(ctx.work_type.id),
+        confidence_levels=get_confidence_levels(),
+        frequency_options=get_frequency_options(),
+        priority_levels=get_priority_levels(),
+    )
+
+
+@admin_final_bp.post("/<event>/<dept>/<work_type_slug>/item/<public_id>/add-line")
+@admin_final_bp.post("/<event>/<dept>/budget/item/<public_id>/add-line")
+def line_add_submit(event: str, dept: str, public_id: str, work_type_slug: str = "budget"):
+    user_ctx = get_user_ctx()
+    require_budget_admin(user_ctx)
+    work_item, ctx = _get_work_item_for_add(event, dept, public_id, work_type_slug)
+
+    account, spend_type, group, errors = _validate_account_selection(ctx, request.form)
+    values, value_errors = _parse_line_numbers(request.form)
+    note, note_errors = _parse_note(request.form)
+    errors.extend(value_errors)
+    errors.extend(note_errors)
+
+    line = None
+    if not errors:
+        line, error = admin_add_line(
+            work_item=work_item, user_ctx=user_ctx,
+            expense_account=account, spend_type=spend_type, approval_group=group,
+            quantity=values["quantity"], unit_price_cents=values["unit_price_cents"],
+            confidence_level=values["confidence_level"], frequency=values["frequency"],
+            priority=values["priority"], warehouse_flag=values["warehouse_flag"],
+            description=values["description"], note=note,
+        )
+        if not line:
+            errors.append(error)
+
+    if errors:
+        db.session.rollback()
+        for e in errors:
+            flash(e, "error")
+        return redirect(url_for(
+            "admin_final.line_add",
+            event=event, dept=dept, public_id=public_id,
+        ))
+
+    db.session.commit()
+    _notify_group_nonblocking(work_item, group.id)
+
+    flash(
+        f"Line {line.line_number} added and routed to {group.name} for review.",
+        "success",
+    )
+    return redirect(url_for(
+        "work.work_item_detail",
+        event=event, dept=dept, public_id=public_id,
+    ))

--- a/app/routes/admin_final/line_admin.py
+++ b/app/routes/admin_final/line_admin.py
@@ -1,0 +1,206 @@
+"""
+Admin line tools: change a line's expense account, or add a line to an
+in-review request. Budget-admin-only. Both actions route the affected
+line through the approval-group stage so nothing skips review.
+"""
+from decimal import Decimal, InvalidOperation
+
+from flask import render_template, redirect, url_for, request, abort, flash
+
+from app import db
+from app.models import (
+    ApprovalGroup,
+    ConfidenceLevel,
+    ExpenseAccount,
+    FrequencyOption,
+    PriorityLevel,
+    SPEND_TYPE_MODE_SINGLE_LOCKED,
+)
+from app.routes import get_user_ctx
+from app.routes.work.helpers import (
+    format_currency,
+    get_allowed_spend_types,
+    get_confidence_levels,
+    get_effective_account_type,
+    get_frequency_options,
+    get_priority_levels,
+)
+from . import admin_final_bp
+from .helpers import (
+    admin_add_line,
+    change_line_expense_account,
+    require_budget_admin,
+)
+from .reviews import _get_work_item_and_line
+
+
+def _get_admin_expense_accounts(event_cycle_id: int) -> list:
+    """All active, non-fixed accounts — admins bypass department visibility."""
+    accounts = ExpenseAccount.query.filter_by(is_active=True).order_by(
+        ExpenseAccount.sort_order.asc(), ExpenseAccount.name.asc()
+    ).all()
+    return [
+        a for a in accounts
+        if not get_effective_account_type(a, event_cycle_id)[0]
+    ]
+
+
+def _get_budget_approval_groups(work_type_id: int) -> list:
+    return ApprovalGroup.query.filter_by(
+        work_type_id=work_type_id, is_active=True,
+    ).order_by(ApprovalGroup.name.asc()).all()
+
+
+def _validate_account_selection(ctx, form):
+    """
+    Validate expense_account_id / spend_type_id / approval_group_id.
+    Returns (account, spend_type, group, errors).
+    """
+    errors = []
+    account = spend_type = group = None
+
+    account_id_str = (form.get("expense_account_id") or "").strip()
+    if not account_id_str:
+        errors.append("Expense account is required.")
+    else:
+        try:
+            account = ExpenseAccount.query.get(int(account_id_str))
+        except ValueError:
+            account = None
+        if not account or not account.is_active:
+            errors.append("Invalid expense account.")
+            account = None
+        elif get_effective_account_type(account, ctx.event_cycle.id)[0]:
+            errors.append("Fixed-cost expense accounts cannot be used here.")
+            account = None
+
+    if account:
+        if account.spend_type_mode == SPEND_TYPE_MODE_SINGLE_LOCKED:
+            spend_type = account.default_spend_type
+            if not spend_type:
+                errors.append("Expense account has no default spend type configured.")
+        else:
+            allowed = {st.id: st for st in get_allowed_spend_types(account)}
+            spend_type_id_str = (form.get("spend_type_id") or "").strip()
+            if not spend_type_id_str:
+                errors.append("Spend type is required.")
+            else:
+                try:
+                    spend_type = allowed.get(int(spend_type_id_str))
+                except ValueError:
+                    spend_type = None
+                if not spend_type:
+                    errors.append("Selected spend type is not allowed for this expense account.")
+
+    group_id_str = (form.get("approval_group_id") or "").strip()
+    if not group_id_str:
+        errors.append("Review group is required.")
+    else:
+        try:
+            group = ApprovalGroup.query.get(int(group_id_str))
+        except ValueError:
+            group = None
+        if not group or not group.is_active or group.work_type_id != ctx.work_type.id:
+            errors.append("Invalid review group.")
+            group = None
+
+    return account, spend_type, group, errors
+
+
+def _parse_note(form):
+    """Required note; CRLF-normalized before length check."""
+    from app.routes.admin.helpers import MAX_FREEFORM_TEXT_LENGTH
+    raw = (form.get("note") or "").replace("\r\n", "\n").replace("\r", "\n")
+    errors = []
+    if not raw.strip():
+        errors.append("A note explaining this change is required.")
+    if len(raw) > MAX_FREEFORM_TEXT_LENGTH:
+        errors.append(f"Note is too long (max {MAX_FREEFORM_TEXT_LENGTH:,} characters).")
+    return raw.strip(), errors
+
+
+def _notify_group_nonblocking(work_item, group_id):
+    """Post-commit notification, mirroring dispatch_to_queue's pattern."""
+    try:
+        from app.services.notifications import notify_work_item_dispatched
+        notify_work_item_dispatched(work_item, [group_id])
+        db.session.commit()  # persist NotificationLog rows
+    except Exception:
+        db.session.rollback()
+        import logging
+        logging.getLogger(__name__).exception(
+            "Failed to send admin-line-tool notification for %s", work_item.public_id
+        )
+
+
+# ============================================================
+# Change Expense Account
+# ============================================================
+
+@admin_final_bp.get("/<event>/<dept>/<work_type_slug>/item/<public_id>/line/<int:line_num>/change-account")
+@admin_final_bp.get("/<event>/<dept>/budget/item/<public_id>/line/<int:line_num>/change-account")
+def line_change_account(event: str, dept: str, public_id: str, line_num: int, work_type_slug: str = "budget"):
+    """Form: move a line to a different expense account + review group."""
+    user_ctx = get_user_ctx()
+    require_budget_admin(user_ctx)
+    work_item, line, ctx = _get_work_item_and_line(event, dept, public_id, line_num, work_type_slug)
+
+    detail = line.budget_detail
+    if not detail:
+        abort(404, "Line has no budget details.")
+
+    expense_accounts = _get_admin_expense_accounts(ctx.event_cycle.id)
+    from app.routes.work.lines import build_spend_types_by_account
+    return render_template(
+        "admin_final/line_change_account.html",
+        ctx=ctx,
+        work_item=work_item,
+        line=line,
+        detail=detail,
+        expense_accounts=expense_accounts,
+        spend_types_by_account=build_spend_types_by_account(expense_accounts),
+        approval_groups=_get_budget_approval_groups(ctx.work_type.id),
+        format_currency=format_currency,
+    )
+
+
+@admin_final_bp.post("/<event>/<dept>/<work_type_slug>/item/<public_id>/line/<int:line_num>/change-account")
+@admin_final_bp.post("/<event>/<dept>/budget/item/<public_id>/line/<int:line_num>/change-account")
+def line_change_account_submit(event: str, dept: str, public_id: str, line_num: int, work_type_slug: str = "budget"):
+    user_ctx = get_user_ctx()
+    require_budget_admin(user_ctx)
+    work_item, line, ctx = _get_work_item_and_line(event, dept, public_id, line_num, work_type_slug)
+
+    account, spend_type, group, errors = _validate_account_selection(ctx, request.form)
+    note, note_errors = _parse_note(request.form)
+    errors.extend(note_errors)
+
+    if not errors:
+        success, error = change_line_expense_account(
+            line=line, work_item=work_item,
+            new_account=account, new_spend_type=spend_type,
+            new_group=group, note=note, user_ctx=user_ctx,
+        )
+        if not success:
+            errors.append(error)
+
+    if errors:
+        db.session.rollback()
+        for e in errors:
+            flash(e, "error")
+        return redirect(url_for(
+            "admin_final.line_change_account",
+            event=event, dept=dept, public_id=public_id, line_num=line_num,
+        ))
+
+    db.session.commit()
+    _notify_group_nonblocking(work_item, group.id)
+
+    flash(
+        f"Line {line_num} moved to {account.name} and sent back to {group.name} for review.",
+        "success",
+    )
+    return redirect(url_for(
+        "admin_final.line_review",
+        event=event, dept=dept, public_id=public_id, line_num=line_num,
+    ))

--- a/app/routes/admin_final/line_admin.py
+++ b/app/routes/admin_final/line_admin.py
@@ -200,8 +200,10 @@ def line_change_account_submit(event: str, dept: str, public_id: str, line_num: 
         f"Line {line_num} moved to {account.name} and sent back to {group.name} for review.",
         "success",
     )
+    # Land on the approvals-side line page — the surface admins actually
+    # review from (admin_final.line_review is only reached via the queue).
     return redirect(url_for(
-        "admin_final.line_review",
+        "approvals.line_review",
         event=event, dept=dept, public_id=public_id, line_num=line_num,
     ))
 

--- a/app/templates/admin_final/line_add.html
+++ b/app/templates/admin_final/line_add.html
@@ -19,6 +19,12 @@
       The requester can see the note you enter.
     </div>
 
+    <div style="background:#fee2e2; border:1px solid #dc2626; border-radius:6px; padding:12px; margin-bottom:16px;">
+      <strong>Lines cannot be easily deleted</strong> once a request is under review.
+      Only add this line if you are sure it belongs on this request &mdash; if in doubt,
+      use a comment or kickback to ask the requester first.
+    </div>
+
     <form method="post" action="{{ url_for('admin_final.line_add_submit', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id) }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 

--- a/app/templates/admin_final/line_add.html
+++ b/app/templates/admin_final/line_add.html
@@ -1,0 +1,169 @@
+{# templates/admin_final/line_add.html #}
+{% extends "layout/base.html" %}
+
+{% block title %}Add Line (Admin) - {{ work_item.public_id }}{% endblock %}
+
+{% block content %}
+  <h1 style="margin:0;">Add Line (Admin)</h1>
+  <div class="muted" style="margin-top:4px;">
+    <a href="{{ url_for('work.work_item_detail', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id) }}">
+      {{ work_item.public_id }}
+    </a>
+    &middot; {{ ctx.department.name }} &middot; {{ ctx.event_cycle.name }}
+  </div>
+
+  <section class="card" style="max-width: 720px; margin-top: 16px;">
+    <div style="background:#fef3c7; border:1px solid #f59e0b; border-radius:6px; padding:12px; margin-bottom:16px;">
+      <strong>Heads up:</strong> this adds a new line to a request that is already under review.
+      The line starts as PENDING and is routed to the review group selected below.
+      The requester can see the note you enter.
+    </div>
+
+    <form method="post" action="{{ url_for('admin_final.line_add_submit', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id) }}">
+
+      <div class="mb-16">
+        <label for="expense_account_id"><strong>Expense Account</strong> <span style="color: red;">*</span></label>
+        <select name="expense_account_id" id="expense_account_id" required class="mt-4">
+          <option value="">(Select expense account)</option>
+          {% for acc in expense_accounts %}
+            <option value="{{ acc.id }}" data-approval-group-id="{{ acc.approval_group_id or '' }}">
+              {{ acc.name }}
+            </option>
+          {% endfor %}
+        </select>
+        <div class="muted small mt-4">All active accounts are listed (admin view — department visibility does not apply).</div>
+      </div>
+
+      <div class="mb-16" id="spend_type_container">
+        <label for="spend_type_id"><strong>Spend Type</strong> <span style="color: red;">*</span></label>
+        <select name="spend_type_id" id="spend_type_id" class="mt-4">
+          <option value="">(Select spend type)</option>
+        </select>
+        <div class="muted small mt-4" id="spend_type_hint"></div>
+      </div>
+
+      <div class="mb-16" style="display:flex; gap:16px;">
+        <div style="flex:1;">
+          <label for="quantity"><strong>Quantity</strong> <span style="color: red;">*</span></label>
+          <input type="number" step="any" min="0" name="quantity" id="quantity" value="1" required class="mt-4">
+        </div>
+        <div style="flex:1;">
+          <label for="unit_price"><strong>Unit Price ($)</strong> <span style="color: red;">*</span></label>
+          <input type="number" step="0.01" min="0" name="unit_price" id="unit_price" required class="mt-4">
+        </div>
+      </div>
+
+      <div class="mb-16" style="display:flex; gap:16px;">
+        <div style="flex:1;">
+          <label for="confidence_level_id"><strong>Confidence</strong> <span style="color: red;">*</span></label>
+          <select name="confidence_level_id" id="confidence_level_id" required class="mt-4">
+            <option value="">(Select)</option>
+            {% for level in confidence_levels %}
+              <option value="{{ level.id }}">{{ level.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div style="flex:1;">
+          <label for="frequency_id"><strong>Frequency</strong> <span style="color: red;">*</span></label>
+          <select name="frequency_id" id="frequency_id" required class="mt-4">
+            <option value="">(Select)</option>
+            {% for freq in frequency_options %}
+              <option value="{{ freq.id }}">{{ freq.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div style="flex:1;">
+          <label for="priority_id"><strong>Priority</strong> <span style="color: red;">*</span></label>
+          <select name="priority_id" id="priority_id" required class="mt-4">
+            <option value="">(Select)</option>
+            {% for pri in priority_levels %}
+              <option value="{{ pri.id }}">{{ pri.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <div class="mb-16">
+        <label>
+          <input type="checkbox" name="warehouse_flag"> Warehouse item
+        </label>
+      </div>
+
+      <div class="mb-16">
+        <label for="description"><strong>Description</strong></label>
+        <textarea name="description" id="description" rows="3" class="mt-4"></textarea>
+      </div>
+
+      <div class="mb-16">
+        <label for="approval_group_id"><strong>Route To Review Group</strong> <span style="color: red;">*</span></label>
+        <select name="approval_group_id" id="approval_group_id" required class="mt-4">
+          <option value="">(Select review group)</option>
+          {% for group in approval_groups %}
+            <option value="{{ group.id }}">{{ group.name }}</option>
+          {% endfor %}
+        </select>
+        <div class="muted small mt-4">Defaults to the account's usual group when one is configured &mdash; confirm or override.</div>
+      </div>
+
+      <div class="mb-16">
+        <label for="note"><strong>Note</strong> <span style="color: red;">*</span></label>
+        <textarea name="note" id="note" rows="3" required class="mt-4"
+                  placeholder="Why is this line being added by an admin? Visible to the requester and reviewers."></textarea>
+      </div>
+
+      <div class="btn-row">
+        <button type="submit" class="btn btn-primary">Add Line &amp; Route For Review</button>
+        <a class="btn" href="{{ url_for('work.work_item_detail', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id) }}">Cancel</a>
+      </div>
+    </form>
+  </section>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ csp_nonce }}">
+  const spendTypesByAccount = {{ spend_types_by_account | tojson | safe }};
+
+  const accountSelect = document.getElementById('expense_account_id');
+  const spendTypeSelect = document.getElementById('spend_type_id');
+  const spendTypeContainer = document.getElementById('spend_type_container');
+  const spendTypeHint = document.getElementById('spend_type_hint');
+  const groupSelect = document.getElementById('approval_group_id');
+
+  function refreshSpendTypes() {
+    const info = spendTypesByAccount[accountSelect.value];
+    spendTypeSelect.innerHTML = '<option value="">(Select spend type)</option>';
+    if (!info) {
+      spendTypeContainer.style.display = '';
+      spendTypeHint.textContent = '';
+      return;
+    }
+    if (info.mode === 'SINGLE_LOCKED') {
+      spendTypeContainer.style.display = 'none';
+      spendTypeSelect.removeAttribute('required');
+      spendTypeHint.textContent = 'Spend type is locked by this account.';
+      return;
+    }
+    spendTypeContainer.style.display = '';
+    spendTypeSelect.setAttribute('required', 'required');
+    for (const t of info.types) {
+      const opt = document.createElement('option');
+      opt.value = t.id;
+      opt.textContent = t.name;
+      spendTypeSelect.appendChild(opt);
+    }
+  }
+
+  function defaultGroupFromAccount() {
+    const opt = accountSelect.options[accountSelect.selectedIndex];
+    const gid = opt ? opt.getAttribute('data-approval-group-id') : '';
+    if (gid) groupSelect.value = gid;
+  }
+
+  accountSelect.addEventListener('change', function () {
+    refreshSpendTypes();
+    defaultGroupFromAccount();
+  });
+
+  refreshSpendTypes();
+</script>
+{% endblock %}

--- a/app/templates/admin_final/line_add.html
+++ b/app/templates/admin_final/line_add.html
@@ -20,6 +20,7 @@
     </div>
 
     <form method="post" action="{{ url_for('admin_final.line_add_submit', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id) }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
       <div class="mb-16">
         <label for="expense_account_id"><strong>Expense Account</strong> <span style="color: red;">*</span></label>

--- a/app/templates/admin_final/line_change_account.html
+++ b/app/templates/admin_final/line_change_account.html
@@ -27,6 +27,7 @@
     </div>
 
     <form method="post" action="{{ url_for('admin_final.line_change_account_submit', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
       <div class="mb-16">
         <label for="expense_account_id"><strong>New Expense Account</strong> <span style="color: red;">*</span></label>

--- a/app/templates/admin_final/line_change_account.html
+++ b/app/templates/admin_final/line_change_account.html
@@ -6,7 +6,7 @@
 {% block content %}
   <h1 style="margin:0;">Change Expense Account &mdash; Line {{ line.line_number }}</h1>
   <div class="muted" style="margin-top:4px;">
-    <a href="{{ url_for('admin_final.line_review', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">
+    <a href="{{ url_for('approvals.line_review', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">
       {{ work_item.public_id }}
     </a>
     &middot; {{ ctx.department.name }} &middot; {{ ctx.event_cycle.name }}
@@ -71,7 +71,7 @@
 
       <div class="btn-row">
         <button type="submit" class="btn btn-primary">Change Account &amp; Send For Re-Review</button>
-        <a class="btn" href="{{ url_for('admin_final.line_review', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">Cancel</a>
+        <a class="btn" href="{{ url_for('approvals.line_review', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">Cancel</a>
       </div>
     </form>
   </section>

--- a/app/templates/admin_final/line_change_account.html
+++ b/app/templates/admin_final/line_change_account.html
@@ -1,0 +1,128 @@
+{# templates/admin_final/line_change_account.html #}
+{% extends "layout/base.html" %}
+
+{% block title %}Change Expense Account - Line {{ line.line_number }} - {{ work_item.public_id }}{% endblock %}
+
+{% block content %}
+  <h1 style="margin:0;">Change Expense Account &mdash; Line {{ line.line_number }}</h1>
+  <div class="muted" style="margin-top:4px;">
+    <a href="{{ url_for('admin_final.line_review', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">
+      {{ work_item.public_id }}
+    </a>
+    &middot; {{ ctx.department.name }} &middot; {{ ctx.event_cycle.name }}
+  </div>
+
+  <section class="card" style="max-width: 720px; margin-top: 16px;">
+    <div class="meta">
+      <div><strong>Current Expense Account:</strong> {{ detail.expense_account.name if detail.expense_account else '-' }}</div>
+      <div><strong>Current Spend Type:</strong> {{ detail.spend_type.name if detail.spend_type else '-' }}</div>
+      <div><strong>Currently Routed To:</strong> {{ detail.routed_approval_group.name if detail.routed_approval_group else 'Unassigned' }}</div>
+      <div><strong>Description:</strong> {{ detail.description or '-' }}</div>
+    </div>
+
+    <div style="background:#fef3c7; border:1px solid #f59e0b; border-radius:6px; padding:12px; margin:16px 0;">
+      <strong>Heads up:</strong> changing the expense account will <strong>reset this line to PENDING</strong>
+      and send it back to the review group selected below. Comments, notes, and audit history are kept
+      &mdash; nothing is deleted &mdash; but any prior approval decision on this line is cleared.
+    </div>
+
+    <form method="post" action="{{ url_for('admin_final.line_change_account_submit', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">
+
+      <div class="mb-16">
+        <label for="expense_account_id"><strong>New Expense Account</strong> <span style="color: red;">*</span></label>
+        <select name="expense_account_id" id="expense_account_id" required class="mt-4">
+          <option value="">(Select expense account)</option>
+          {% for acc in expense_accounts %}
+            <option value="{{ acc.id }}"
+                    data-approval-group-id="{{ acc.approval_group_id or '' }}"
+                    {% if acc.id == detail.expense_account_id %}selected{% endif %}>
+              {{ acc.name }}
+            </option>
+          {% endfor %}
+        </select>
+        <div class="muted small mt-4">All active accounts are listed (admin view — department visibility does not apply).</div>
+      </div>
+
+      <div class="mb-16" id="spend_type_container">
+        <label for="spend_type_id"><strong>Spend Type</strong> <span style="color: red;">*</span></label>
+        <select name="spend_type_id" id="spend_type_id" class="mt-4">
+          <option value="">(Select spend type)</option>
+        </select>
+        <div class="muted small mt-4" id="spend_type_hint"></div>
+      </div>
+
+      <div class="mb-16">
+        <label for="approval_group_id"><strong>Send Back To Review Group</strong> <span style="color: red;">*</span></label>
+        <select name="approval_group_id" id="approval_group_id" required class="mt-4">
+          <option value="">(Select review group)</option>
+          {% for group in approval_groups %}
+            <option value="{{ group.id }}">{{ group.name }}</option>
+          {% endfor %}
+        </select>
+        <div class="muted small mt-4">Defaults to the new account's usual group when one is configured &mdash; confirm or override.</div>
+      </div>
+
+      <div class="mb-16">
+        <label for="note"><strong>Note</strong> <span style="color: red;">*</span></label>
+        <textarea name="note" id="note" rows="3" required class="mt-4"
+                  placeholder="Why is the account being changed? Visible to the requester and reviewers."></textarea>
+      </div>
+
+      <div class="btn-row">
+        <button type="submit" class="btn btn-primary">Change Account &amp; Send For Re-Review</button>
+        <a class="btn" href="{{ url_for('admin_final.line_review', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">Cancel</a>
+      </div>
+    </form>
+  </section>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ csp_nonce }}">
+  const spendTypesByAccount = {{ spend_types_by_account | tojson | safe }};
+  const currentSpendTypeId = '{{ detail.spend_type_id or "" }}';
+
+  const accountSelect = document.getElementById('expense_account_id');
+  const spendTypeSelect = document.getElementById('spend_type_id');
+  const spendTypeContainer = document.getElementById('spend_type_container');
+  const spendTypeHint = document.getElementById('spend_type_hint');
+  const groupSelect = document.getElementById('approval_group_id');
+
+  function refreshSpendTypes(preselectId) {
+    const info = spendTypesByAccount[accountSelect.value];
+    spendTypeSelect.innerHTML = '<option value="">(Select spend type)</option>';
+    if (!info) {
+      spendTypeContainer.style.display = '';
+      spendTypeHint.textContent = '';
+      return;
+    }
+    if (info.mode === 'SINGLE_LOCKED') {
+      spendTypeContainer.style.display = 'none';
+      spendTypeSelect.removeAttribute('required');
+      spendTypeHint.textContent = 'Spend type is locked by this account.';
+      return;
+    }
+    spendTypeContainer.style.display = '';
+    spendTypeSelect.setAttribute('required', 'required');
+    for (const t of info.types) {
+      const opt = document.createElement('option');
+      opt.value = t.id;
+      opt.textContent = t.name;
+      if (String(t.id) === String(preselectId)) opt.selected = true;
+      spendTypeSelect.appendChild(opt);
+    }
+  }
+
+  function defaultGroupFromAccount() {
+    const opt = accountSelect.options[accountSelect.selectedIndex];
+    const gid = opt ? opt.getAttribute('data-approval-group-id') : '';
+    if (gid) groupSelect.value = gid;
+  }
+
+  accountSelect.addEventListener('change', function () {
+    refreshSpendTypes('');
+    defaultGroupFromAccount();
+  });
+
+  refreshSpendTypes(currentSpendTypeId);
+</script>
+{% endblock %}

--- a/app/templates/admin_final/line_review.html
+++ b/app/templates/admin_final/line_review.html
@@ -72,7 +72,12 @@
         <h3 style="margin:0 0 12px 0;">Line Details</h3>
 
         <div class="meta">
-          <div><strong>Expense Account:</strong> {{ detail.expense_account.name if detail and detail.expense_account else '-' }}</div>
+          <div>
+            <strong>Expense Account:</strong> {{ detail.expense_account.name if detail and detail.expense_account else '-' }}
+            {% if detail and work_item.status in ("SUBMITTED", "NEEDS_INFO") %}
+              <a class="small" href="{{ url_for('admin_final.line_change_account', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">(edit)</a>
+            {% endif %}
+          </div>
           {% if detail and detail.expense_account and detail.expense_account.description %}
             <div class="muted small">{{ detail.expense_account.description|markdown_links|safe }}</div>
           {% endif %}

--- a/app/templates/budget/_work_item_lines_table.html
+++ b/app/templates/budget/_work_item_lines_table.html
@@ -2,7 +2,12 @@
 {# Partial: Budget lines table for work_item_detail.html #}
 {% from "macros/status_pill.html" import render_status_pill %}
 
-<h3 style="margin:0 0 12px 0;">Budget Lines</h3>
+<div style="display:flex; justify-content:space-between; align-items:center; gap:12px; margin-bottom:12px; flex-wrap:wrap;">
+  <h3 style="margin:0;">Budget Lines</h3>
+  {% if perms.is_worktype_admin and status in ("SUBMITTED", "NEEDS_INFO") %}
+    <a class="btn" href="{{ url_for('admin_final.line_add', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id) }}">+ Add Line (Admin)</a>
+  {% endif %}
+</div>
 
 {% if lines %}
   {% set show_approved_column = status == "FINALIZED" or totals.approved > 0 %}

--- a/app/templates/budget/line_review.html
+++ b/app/templates/budget/line_review.html
@@ -92,7 +92,12 @@
         <h3 style="margin:0 0 12px 0;">Line Details</h3>
 
         <div class="meta">
-          <div><strong>Expense Account:</strong> {{ detail.expense_account.name if detail and detail.expense_account else '-' }}</div>
+          <div>
+            <strong>Expense Account:</strong> {{ detail.expense_account.name if detail and detail.expense_account else '-' }}
+            {% if detail and perms.is_worktype_admin and work_item.status in ("SUBMITTED", "NEEDS_INFO") %}
+              <a class="small" href="{{ url_for('admin_final.line_change_account', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id, line_num=line.line_number) }}">(edit)</a>
+            {% endif %}
+          </div>
           {% if detail and detail.expense_account and detail.expense_account.description %}
             <div class="muted small">{{ detail.expense_account.description|markdown_links|safe }}</div>
           {% endif %}

--- a/tests/integration/test_admin_line_tools.py
+++ b/tests/integration/test_admin_line_tools.py
@@ -1,0 +1,147 @@
+"""
+Integration tests for budget-admin line tools:
+expense account correction + admin add-line on in-review requests.
+"""
+from datetime import datetime, timedelta
+
+from app import db
+from app.models import (
+    ApprovalGroup,
+    ConfidenceLevel,
+    ExpenseAccount,
+    FrequencyOption,
+    PriorityLevel,
+    WorkLineComment,
+    WorkLineReview,
+    REVIEW_STAGE_APPROVAL_GROUP,
+    REVIEW_STATUS_APPROVED,
+    REVIEW_STATUS_PENDING,
+    SPEND_TYPE_MODE_SINGLE_LOCKED,
+    WORK_ITEM_STATUS_FINALIZED,
+    WORK_ITEM_STATUS_SUBMITTED,
+    WORK_LINE_STATUS_APPROVED,
+    WORK_LINE_STATUS_PENDING,
+)
+from app.routes import UserContext
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = user_id
+
+
+def _admin_ctx():
+    return UserContext(
+        user_id="test:admin", user=None, roles=("SUPER_ADMIN",),
+        is_super_admin=True, approval_group_ids=set(),
+    )
+
+
+def _make_submitted(data, decided=False):
+    """Promote seed_draft_work_item's item to SUBMITTED with an AG review,
+    mirroring what dispatch_to_queue creates (dispatch/dashboard.py:263-277)."""
+    data["work_item"].status = WORK_ITEM_STATUS_SUBMITTED
+    data["line"].current_review_stage = REVIEW_STAGE_APPROVAL_GROUP
+    review = WorkLineReview(
+        work_line_id=data["line"].id,
+        stage=REVIEW_STAGE_APPROVAL_GROUP,
+        approval_group_id=data["approval_group"].id,
+        status=REVIEW_STATUS_APPROVED if decided else REVIEW_STATUS_PENDING,
+        created_by_user_id="test:admin",
+    )
+    db.session.add(review)
+    if decided:
+        data["line"].status = WORK_LINE_STATUS_APPROVED
+        data["line"].approved_amount_cents = 5000
+    db.session.commit()
+    return review
+
+
+def _make_target_account(data):
+    """A second account (SINGLE_LOCKED to the seeded spend type) + second group,
+    simulating 'the account it should have been'."""
+    group2 = ApprovalGroup(
+        work_type_id=data["work_type"].id,
+        code="HOTEL", name="Hotel Team", is_active=True,
+    )
+    db.session.add(group2)
+    db.session.flush()
+    acct2 = ExpenseAccount(
+        code="TEST_ACC_2", name="Correct Account", is_active=True,
+        spend_type_mode=SPEND_TYPE_MODE_SINGLE_LOCKED,
+        default_spend_type_id=data["spend_type"].id,
+        approval_group_id=group2.id,
+    )
+    db.session.add(acct2)
+    db.session.commit()
+    return acct2, group2
+
+
+def _checkout(data):
+    """Simulate an active reviewer checkout."""
+    item = data["work_item"]
+    item.checked_out_by_user_id = "test:reviewer"
+    item.checked_out_at = datetime.utcnow()
+    item.checked_out_expires_at = datetime.utcnow() + timedelta(hours=1)
+    db.session.commit()
+
+
+class TestChangeLineExpenseAccount:
+    def test_change_resets_line_and_reroutes(self, app, client, seed_draft_work_item):
+        from app.routes.admin_final.helpers import change_line_expense_account
+        data = seed_draft_work_item
+        _make_submitted(data, decided=True)
+        acct2, group2 = _make_target_account(data)
+
+        ok, err = change_line_expense_account(
+            line=data["line"], work_item=data["work_item"],
+            new_account=acct2, new_spend_type=data["spend_type"],
+            new_group=group2, note="Picked the wrong account originally",
+            user_ctx=_admin_ctx(),
+        )
+        db.session.commit()
+
+        assert ok, err
+        assert data["detail"].expense_account_id == acct2.id
+        assert data["detail"].routed_approval_group_id == group2.id
+        assert data["line"].status == WORK_LINE_STATUS_PENDING
+        assert data["line"].approved_amount_cents is None
+        assert data["line"].current_review_stage == REVIEW_STAGE_APPROVAL_GROUP
+        ag = WorkLineReview.query.filter_by(
+            work_line_id=data["line"].id, stage=REVIEW_STAGE_APPROVAL_GROUP,
+        ).one()
+        assert ag.status == REVIEW_STATUS_PENDING
+        assert ag.approval_group_id == group2.id
+        assert ag.decided_at is None
+        comment = WorkLineComment.query.filter_by(work_line_id=data["line"].id).one()
+        assert "[ADMIN ACCOUNT CHANGE]" in comment.body
+
+    def test_blocked_while_checked_out(self, app, client, seed_draft_work_item):
+        from app.routes.admin_final.helpers import change_line_expense_account
+        data = seed_draft_work_item
+        _make_submitted(data)
+        acct2, group2 = _make_target_account(data)
+        _checkout(data)
+
+        ok, err = change_line_expense_account(
+            line=data["line"], work_item=data["work_item"],
+            new_account=acct2, new_spend_type=data["spend_type"],
+            new_group=group2, note="x", user_ctx=_admin_ctx(),
+        )
+        assert not ok
+        assert "checked out" in err
+
+    def test_blocked_when_not_under_review(self, app, client, seed_draft_work_item):
+        from app.routes.admin_final.helpers import change_line_expense_account
+        data = seed_draft_work_item
+        data["work_item"].status = WORK_ITEM_STATUS_FINALIZED
+        db.session.commit()
+        acct2, group2 = _make_target_account(data)
+
+        ok, err = change_line_expense_account(
+            line=data["line"], work_item=data["work_item"],
+            new_account=acct2, new_spend_type=data["spend_type"],
+            new_group=group2, note="x", user_ctx=_admin_ctx(),
+        )
+        assert not ok
+        assert "under review" in err

--- a/tests/integration/test_admin_line_tools.py
+++ b/tests/integration/test_admin_line_tools.py
@@ -86,6 +86,17 @@ def _checkout(data):
     db.session.commit()
 
 
+def _make_line_refs():
+    """Reference rows required by BudgetLineDetail (conftest's create_all
+    skips Alembic data migrations, so tests seed these themselves)."""
+    cl = ConfidenceLevel(code="HIGH", name="High", is_active=True)
+    fq = FrequencyOption(code="ONE_TIME", name="One Time", is_active=True)
+    pr = PriorityLevel(code="MUST", name="Must Have", is_active=True)
+    db.session.add_all([cl, fq, pr])
+    db.session.commit()
+    return cl, fq, pr
+
+
 class TestChangeLineExpenseAccount:
     def test_change_resets_line_and_reroutes(self, app, client, seed_draft_work_item):
         from app.routes.admin_final.helpers import change_line_expense_account
@@ -144,4 +155,72 @@ class TestChangeLineExpenseAccount:
             new_group=group2, note="x", user_ctx=_admin_ctx(),
         )
         assert not ok
+        assert "under review" in err
+
+
+class TestAdminAddLine:
+    def test_adds_routed_reviewable_line(self, app, client, seed_draft_work_item):
+        from app.routes.admin_final.helpers import admin_add_line
+        data = seed_draft_work_item
+        _make_submitted(data)
+        cl, fq, pr = _make_line_refs()
+
+        line, err = admin_add_line(
+            work_item=data["work_item"], user_ctx=_admin_ctx(),
+            expense_account=data["expense_account"], spend_type=data["spend_type"],
+            approval_group=data["approval_group"],
+            quantity=2, unit_price_cents=12500,
+            confidence_level=cl, frequency=fq, priority=pr,
+            warehouse_flag=False, description="Forgotten major item",
+            note="Missed during original submission",
+        )
+        db.session.commit()
+
+        assert err is None
+        assert line.line_number == 2
+        assert line.status == WORK_LINE_STATUS_PENDING
+        assert line.current_review_stage == REVIEW_STAGE_APPROVAL_GROUP
+        assert line.budget_detail.routed_approval_group_id == data["approval_group"].id
+        review = WorkLineReview.query.filter_by(
+            work_line_id=line.id, stage=REVIEW_STAGE_APPROVAL_GROUP,
+        ).one()
+        assert review.status == REVIEW_STATUS_PENDING
+        assert review.approval_group_id == data["approval_group"].id
+        comment = WorkLineComment.query.filter_by(work_line_id=line.id).one()
+        assert "[ADMIN LINE ADDED]" in comment.body
+
+    def test_blocked_while_checked_out(self, app, client, seed_draft_work_item):
+        from app.routes.admin_final.helpers import admin_add_line
+        data = seed_draft_work_item
+        _make_submitted(data)
+        cl, fq, pr = _make_line_refs()
+        _checkout(data)
+
+        line, err = admin_add_line(
+            work_item=data["work_item"], user_ctx=_admin_ctx(),
+            expense_account=data["expense_account"], spend_type=data["spend_type"],
+            approval_group=data["approval_group"],
+            quantity=1, unit_price_cents=100,
+            confidence_level=cl, frequency=fq, priority=pr,
+            warehouse_flag=False, description="", note="x",
+        )
+        assert line is None
+        assert "checked out" in err
+
+    def test_blocked_when_not_under_review(self, app, client, seed_draft_work_item):
+        from app.routes.admin_final.helpers import admin_add_line
+        data = seed_draft_work_item
+        data["work_item"].status = WORK_ITEM_STATUS_FINALIZED
+        db.session.commit()
+        cl, fq, pr = _make_line_refs()
+
+        line, err = admin_add_line(
+            work_item=data["work_item"], user_ctx=_admin_ctx(),
+            expense_account=data["expense_account"], spend_type=data["spend_type"],
+            approval_group=data["approval_group"],
+            quantity=1, unit_price_cents=100,
+            confidence_level=cl, frequency=fq, priority=pr,
+            warehouse_flag=False, description="", note="x",
+        )
+        assert line is None
         assert "under review" in err

--- a/tests/integration/test_admin_line_tools.py
+++ b/tests/integration/test_admin_line_tools.py
@@ -294,3 +294,62 @@ class TestChangeAccountRoutes:
             },
         )
         assert resp.status_code == 403
+
+
+class TestAdminAddLineRoutes:
+    def test_get_form_renders_for_admin(self, app, client, seed_draft_work_item):
+        data = seed_draft_work_item
+        _make_submitted(data)
+        _make_line_refs()
+        _login(client, "test:admin")
+
+        resp = client.get(_url(app, "admin_final.line_add", data))
+        assert resp.status_code == 200
+        assert b"Add Line (Admin)" in resp.data
+
+    def test_post_creates_routed_line(self, app, client, seed_draft_work_item, monkeypatch):
+        data = seed_draft_work_item
+        _make_submitted(data)
+        acct2, group2 = _make_target_account(data)
+        cl, fq, pr = _make_line_refs()
+        _login(client, "test:admin")
+        monkeypatch.setattr(
+            "app.services.notifications.notify_work_item_dispatched",
+            lambda work_item, group_ids: 0,
+        )
+
+        resp = client.post(
+            _url(app, "admin_final.line_add_submit", data),
+            data={
+                "expense_account_id": str(acct2.id),
+                "approval_group_id": str(group2.id),
+                "quantity": "3",
+                "unit_price": "45.50",
+                "confidence_level_id": str(cl.id),
+                "frequency_id": str(fq.id),
+                "priority_id": str(pr.id),
+                "description": "Forgotten major item",
+                "note": "Missed during original submission",
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        db.session.refresh(data["work_item"])
+        lines = sorted(data["work_item"].lines, key=lambda l: l.line_number)
+        assert len(lines) == 2
+        new_line = lines[-1]
+        assert new_line.budget_detail.unit_price_cents == 4550
+        assert new_line.budget_detail.routed_approval_group_id == group2.id
+        review = WorkLineReview.query.filter_by(
+            work_line_id=new_line.id, stage=REVIEW_STAGE_APPROVAL_GROUP,
+        ).one()
+        assert review.status == REVIEW_STATUS_PENDING
+
+    def test_post_rejected_for_non_admin(self, app, client, seed_draft_work_item):
+        data = seed_draft_work_item
+        _make_submitted(data)
+        _make_line_refs()
+        _login(client, "test:reviewer")
+
+        resp = client.post(_url(app, "admin_final.line_add_submit", data), data={})
+        assert resp.status_code == 403

--- a/tests/integration/test_admin_line_tools.py
+++ b/tests/integration/test_admin_line_tools.py
@@ -4,6 +4,8 @@ expense account correction + admin add-line on in-review requests.
 """
 from datetime import datetime, timedelta
 
+from flask import url_for
+
 from app import db
 from app.models import (
     ApprovalGroup,
@@ -224,3 +226,71 @@ class TestAdminAddLine:
         )
         assert line is None
         assert "under review" in err
+
+
+def _url(app, endpoint, data, **kwargs):
+    with app.test_request_context():
+        return url_for(
+            endpoint,
+            event=data["cycle"].code, dept=data["department"].code,
+            public_id=data["work_item"].public_id, **kwargs,
+        )
+
+
+class TestChangeAccountRoutes:
+    def test_get_form_renders_for_admin(self, app, client, seed_draft_work_item):
+        data = seed_draft_work_item
+        _make_submitted(data)
+        _make_target_account(data)
+        _login(client, "test:admin")
+
+        resp = client.get(_url(app, "admin_final.line_change_account", data, line_num=1))
+        assert resp.status_code == 200
+        assert b"Change Expense Account" in resp.data
+        assert b"Correct Account" in resp.data
+
+    def test_post_changes_account_and_notifies(self, app, client, seed_draft_work_item, monkeypatch):
+        data = seed_draft_work_item
+        _make_submitted(data, decided=True)
+        acct2, group2 = _make_target_account(data)
+        _login(client, "test:admin")
+
+        notified = {}
+        monkeypatch.setattr(
+            "app.services.notifications.notify_work_item_dispatched",
+            lambda work_item, group_ids: notified.update(groups=group_ids) or 0,
+        )
+
+        resp = client.post(
+            _url(app, "admin_final.line_change_account_submit", data, line_num=1),
+            data={
+                "expense_account_id": str(acct2.id),
+                "approval_group_id": str(group2.id),
+                "note": "Wrong account selected at submission",
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        # Route handled the commit in its own session — refresh before asserting
+        # (house pattern, see tests/integration/test_supply_review.py:200)
+        db.session.refresh(data["detail"])
+        db.session.refresh(data["line"])
+        assert data["detail"].expense_account_id == acct2.id
+        assert data["line"].status == WORK_LINE_STATUS_PENDING
+        assert notified["groups"] == [group2.id]
+
+    def test_post_rejected_for_non_admin(self, app, client, seed_draft_work_item):
+        data = seed_draft_work_item
+        _make_submitted(data)
+        acct2, group2 = _make_target_account(data)
+        _login(client, "test:reviewer")
+
+        resp = client.post(
+            _url(app, "admin_final.line_change_account_submit", data, line_num=1),
+            data={
+                "expense_account_id": str(acct2.id),
+                "approval_group_id": str(group2.id),
+                "note": "x",
+            },
+        )
+        assert resp.status_code == 403

--- a/tests/integration/test_admin_line_tools.py
+++ b/tests/integration/test_admin_line_tools.py
@@ -79,10 +79,10 @@ def _make_target_account(data):
     return acct2, group2
 
 
-def _checkout(data):
-    """Simulate an active reviewer checkout."""
+def _checkout(data, user_id="test:reviewer"):
+    """Simulate an active checkout (by another reviewer, unless overridden)."""
     item = data["work_item"]
-    item.checked_out_by_user_id = "test:reviewer"
+    item.checked_out_by_user_id = user_id
     item.checked_out_at = datetime.utcnow()
     item.checked_out_expires_at = datetime.utcnow() + timedelta(hours=1)
     db.session.commit()
@@ -143,6 +143,25 @@ class TestChangeLineExpenseAccount:
         )
         assert not ok
         assert "checked out" in err
+
+    def test_allows_own_checkout(self, app, client, seed_draft_work_item):
+        # The guard protects OTHER reviewers; the admin's own checkout
+        # (Start Reviewing -> spot wrong account -> fix) must not block.
+        from app.routes.admin_final.helpers import change_line_expense_account
+        data = seed_draft_work_item
+        _make_submitted(data)
+        acct2, group2 = _make_target_account(data)
+        _checkout(data, user_id="test:admin")
+
+        ok, err = change_line_expense_account(
+            line=data["line"], work_item=data["work_item"],
+            new_account=acct2, new_spend_type=data["spend_type"],
+            new_group=group2, note="Fixing during my own review",
+            user_ctx=_admin_ctx(),
+        )
+        db.session.commit()
+        assert ok, err
+        assert data["detail"].expense_account_id == acct2.id
 
     def test_blocked_when_not_under_review(self, app, client, seed_draft_work_item):
         from app.routes.admin_final.helpers import change_line_expense_account
@@ -208,6 +227,25 @@ class TestAdminAddLine:
         )
         assert line is None
         assert "checked out" in err
+
+    def test_allows_own_checkout(self, app, client, seed_draft_work_item):
+        from app.routes.admin_final.helpers import admin_add_line
+        data = seed_draft_work_item
+        _make_submitted(data)
+        cl, fq, pr = _make_line_refs()
+        _checkout(data, user_id="test:admin")
+
+        line, err = admin_add_line(
+            work_item=data["work_item"], user_ctx=_admin_ctx(),
+            expense_account=data["expense_account"], spend_type=data["spend_type"],
+            approval_group=data["approval_group"],
+            quantity=1, unit_price_cents=100,
+            confidence_level=cl, frequency=fq, priority=pr,
+            warehouse_flag=False, description="", note="Adding during my own review",
+        )
+        db.session.commit()
+        assert err is None
+        assert line.line_number == 2
 
     def test_blocked_when_not_under_review(self, app, client, seed_draft_work_item):
         from app.routes.admin_final.helpers import admin_add_line
@@ -384,3 +422,14 @@ class TestEntryPoints:
         resp = client.get(_url(app, "work.work_item_detail", data))
         assert resp.status_code == 200
         assert b"add-line" in resp.data
+
+    def test_approvals_line_review_shows_edit_link_for_admin(self, app, client, seed_draft_work_item):
+        # Admins do their reviewing from the approvals-side line page
+        # (budget/line_review.html), so the edit link must appear there too.
+        data = seed_draft_work_item
+        _make_submitted(data)
+        _login(client, "test:admin")
+
+        resp = client.get(_url(app, "approvals.line_review", data, line_num=1))
+        assert resp.status_code == 200
+        assert b"change-account" in resp.data

--- a/tests/integration/test_admin_line_tools.py
+++ b/tests/integration/test_admin_line_tools.py
@@ -353,3 +353,34 @@ class TestAdminAddLineRoutes:
 
         resp = client.post(_url(app, "admin_final.line_add_submit", data), data={})
         assert resp.status_code == 403
+
+
+class TestEntryPoints:
+    def test_admin_line_review_shows_edit_link(self, app, client, seed_draft_work_item):
+        data = seed_draft_work_item
+        _make_submitted(data)
+        _login(client, "test:admin")
+
+        resp = client.get(_url(app, "admin_final.line_review", data, line_num=1))
+        assert resp.status_code == 200
+        assert b"change-account" in resp.data
+
+    def test_edit_link_hidden_when_finalized(self, app, client, seed_draft_work_item):
+        data = seed_draft_work_item
+        _make_submitted(data)
+        data["work_item"].status = WORK_ITEM_STATUS_FINALIZED
+        db.session.commit()
+        _login(client, "test:admin")
+
+        resp = client.get(_url(app, "admin_final.line_review", data, line_num=1))
+        assert resp.status_code == 200
+        assert b"change-account" not in resp.data
+
+    def test_detail_page_shows_add_line_for_admin(self, app, client, seed_draft_work_item):
+        data = seed_draft_work_item
+        _make_submitted(data)
+        _login(client, "test:admin")
+
+        resp = client.get(_url(app, "work.work_item_detail", data))
+        assert resp.status_code == 200
+        assert b"add-line" in resp.data


### PR DESCRIPTION
Two admin-only tools for BUDGET requests that are already under review (`SUBMITTED` or `NEEDS_INFO`),  addressing two recurring situations: a requester picked the wrong expense account, or reviewers notice a major item is missing entirely.
<img width="721" height="1045" alt="image" src="https://github.com/user-attachments/assets/dcbfde0c-b3cc-460b-b814-498739372fb9" />
<img width="831" height="709" alt="image" src="https://github.com/user-attachments/assets/6ec0d98c-6828-4872-9030-1ee5a1ffb8e5" />
<img width="1174" height="652" alt="image" src="https://github.com/user-attachments/assets/8e03f9d5-94dd-4d63-9f36-6e937c4b21d3" />
<img width="800" height="1048" alt="image" src="https://github.com/user-attachments/assets/15776a76-de64-4ef8-aeed-4450bc7b3c90" />

