### PR TITLE
Feature/supply pickup and cart badges

### DIFF
--- a/app/models/supply.py
+++ b/app/models/supply.py
@@ -122,8 +122,8 @@ class SupplyOrderLineDetail(db.Model):
 class SupplyOrderDetail(db.Model):
     """Order-level details: one row per supply-order WorkItem.
 
-    Delivery details live here (not per line) — requesters needing
-    different dates/locations place separate orders.
+    Pickup details live here (not per line) — requesters needing
+    different pickup times place separate orders.
     """
     __tablename__ = "supply_order_details"
 
@@ -133,10 +133,12 @@ class SupplyOrderDetail(db.Model):
         primary_key=True,
     )
 
-    # Nullable in the DB (drafts may not have them yet); required at submit
+    # Nullable in the DB (drafts may not have it yet); required at submit
     # by the cab's validation.
-    needed_by_date = db.Column(db.Date, nullable=True)
-    delivery_location = db.Column(db.String(256), nullable=True)
+    # Stores the display string from form_utils.PICKUP_TIME_OPTIONS as a
+    # snapshot — wording changes to the hardcoded list can't corrupt what
+    # old orders show.
+    pickup_time = db.Column(db.String(120), nullable=True)
     additional_notes = db.Column(db.Text, nullable=True)
 
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)

--- a/app/routes/admin/supply_import_utils.py
+++ b/app/routes/admin/supply_import_utils.py
@@ -104,11 +104,30 @@ def parse_catalog_upload(file_storage) -> list[dict]:
     return records
 
 
+# Blank spreadsheet cells can round-trip through pandas/str() as these
+# placeholder tokens; treat them as blank so they never render as
+# literal "None" text in the catalog.
+_BLANKISH_TOKENS = {"none", "nan", "null"}
+
+
 def _clean_str(value) -> str | None:
     if value is None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _clean_text(value) -> str | None:
+    """Free-text columns only: junk placeholder tokens count as blank.
+
+    Deliberately NOT applied by _parse_bool/_parse_cents/_parse_int —
+    a junk token in a boolean/numeric column must stay a loud import
+    problem, not silently coerce to the default/NULL.
+    """
+    text = _clean_str(value)
+    if text is not None and text.lower() in _BLANKISH_TOKENS:
+        return None
+    return text
 
 
 def _parse_bool(value, default: bool) -> bool:
@@ -163,10 +182,10 @@ def _parse_row_fields(row: dict) -> tuple[dict, list[str]]:
         except ValueError as exc:
             problems.append(str(exc))
 
-    parsed["notes"] = _clean_str(row.get("notes"))
-    parsed["order_guidance"] = _clean_str(row.get("order_guidance"))
-    parsed["location_zone"] = _clean_str(row.get("location_zone"))
-    parsed["bin_location"] = _clean_str(row.get("bin_location"))
+    parsed["notes"] = _clean_text(row.get("notes"))
+    parsed["order_guidance"] = _clean_text(row.get("order_guidance"))
+    parsed["location_zone"] = _clean_text(row.get("location_zone"))
+    parsed["bin_location"] = _clean_text(row.get("bin_location"))
     return parsed, problems
 
 

--- a/app/routes/work/supply/admin.py
+++ b/app/routes/work/supply/admin.py
@@ -16,7 +16,7 @@ worktype admins (or super-admins) by _require_supply_admin.
 from __future__ import annotations
 
 from collections import Counter
-from datetime import date, datetime
+from datetime import datetime
 
 from flask import abort, flash, redirect, render_template, request, url_for
 from sqlalchemy.orm import joinedload, selectinload
@@ -106,8 +106,8 @@ def supply_all_orders():
 
     Mirrors techops_all_requests's shape (app/routes/work/techops/admin.py)
     but SUPPLY-shaped: no monetary column, an item-mix summary (top item
-    names by line count) instead of a service-mix summary, and a needed-by
-    column since delivery timing matters more for warehouse orders than it
+    names by line count) instead of a service-mix summary, and a pickup-time
+    column since pickup timing matters more for warehouse orders than it
     does for TechOps requests.
     """
     user_ctx = get_user_ctx()
@@ -181,7 +181,7 @@ def supply_all_orders():
             "department": portfolio.department,
             "line_count": len(wi.lines),
             "item_mix": item_mix,
-            "needed_by": order_detail.needed_by_date if order_detail else None,
+            "pickup_time": order_detail.pickup_time if order_detail else None,
         })
 
     event_cycles = get_active_event_cycles()
@@ -249,7 +249,7 @@ def _ag_reviews_by_line(line_ids: list[int]) -> dict[int, WorkLineReview]:
 
 @work_bp.get("/admin/supply/queue/")
 def supply_admin_queue():
-    """FestOps finalize queue: SUBMITTED supply orders, soonest-needed first.
+    """FestOps finalize queue: SUBMITTED supply orders, oldest-submitted first.
 
     Per order, surfaces decided/total APPROVAL_GROUP review progress and a
     ready-to-finalize badge when every line has a terminal review decision.
@@ -291,19 +291,22 @@ def supply_admin_queue():
             if review.status in (REVIEW_STATUS_APPROVED, REVIEW_STATUS_REJECTED):
                 decided += 1
         order_detail = order.supply_order_detail
-        needed_by = order_detail.needed_by_date if order_detail else None
         rows.append({
             "work_item": order,
             "department": order.portfolio.department,
             "event_cycle": order.portfolio.event_cycle,
-            "needed_by": needed_by,
+            "pickup_time": order_detail.pickup_time if order_detail else None,
             "decided": decided,
             "total": total,
             "ready": total > 0 and decided == total,
         })
 
-    # Soonest-needed first; orders with no date sort to the bottom.
-    rows.sort(key=lambda r: (r["needed_by"] is None, r["needed_by"] or date.max))
+    # Oldest-submitted first. No pickup-slot urgency sorting — warehouse
+    # staging tools are Phase 2 (spec: 2026-07-08 pickup-time design).
+    rows.sort(key=lambda r: (
+        r["work_item"].submitted_at is None,
+        r["work_item"].submitted_at or r["work_item"].created_at,
+    ))
 
     return render_template(
         "supply/admin_queue.html",

--- a/app/routes/work/supply/catalog.py
+++ b/app/routes/work/supply/catalog.py
@@ -109,6 +109,18 @@ def supply_catalog(event: str, dept: str, public_id: str):
     # (mirrors order.py's own can_edit gate for mutations on this cab).
     can_add = work_item.status == WORK_ITEM_STATUS_DRAFT and perms.can_edit
 
+    # Per-item "already in this order" summary for the badge. Duplicate
+    # adds are separate lines by design (see module docstring), so the
+    # badge shows both the line count and the summed quantity.
+    in_cart: dict[int, dict[str, int]] = {}
+    for line in work_item.lines:
+        d = line.supply_detail
+        if d is None:
+            continue
+        entry = in_cart.setdefault(d.item_id, {"lines": 0, "qty": 0})
+        entry["lines"] += 1
+        entry["qty"] += d.quantity_requested or 0
+
     q = request.args.get("q", "").strip()
     categories, items_by_category, popular_items = _catalog_items(q)
 
@@ -137,6 +149,7 @@ def supply_catalog(event: str, dept: str, public_id: str):
         cart_count=len(work_item.lines),
         catalog_url=catalog_url,
         item_detail_url=item_detail_url,
+        in_cart=in_cart,
     )
 
 
@@ -178,6 +191,7 @@ def supply_catalog_browse(event: str, dept: str):
         cart_count=0,
         catalog_url=catalog_url,
         item_detail_url=item_detail_url,
+        in_cart={},
     )
 
 

--- a/app/routes/work/supply/form_utils.py
+++ b/app/routes/work/supply/form_utils.py
@@ -5,6 +5,20 @@ The engine's submit_work_item SILENTLY SKIPS lines it can't route
 """
 from app.routing.registry import get_approval_group_for_line
 
+# Hardcoded for now (rarely changes; may become per-event config later).
+# "(Select Pickup Time)" is the template's empty-value placeholder, NOT a
+# member of this list. SupplyOrderDetail.pickup_time stores the chosen
+# string verbatim.
+PICKUP_TIME_OTHER = "Other, Please Add Preferred Date / Time to Order Notes"
+
+PICKUP_TIME_OPTIONS = [
+    "Tuesday Evening (after 6 PM)",
+    "Wednesday Mid-day (after 12:01 PM)",
+    "Wednesday Evening (after 6 PM)",
+    "Thursday Morning (small orders only)",
+    PICKUP_TIME_OTHER,
+]
+
 
 def validate_order_for_submit(work_item) -> list[str]:
     errors: list[str] = []
@@ -12,10 +26,13 @@ def validate_order_for_submit(work_item) -> list[str]:
 
     if not work_item.lines:
         errors.append("Add at least one item to the order before submitting.")
-    if detail is None or not detail.needed_by_date:
-        errors.append("Set a needed-by date in Delivery details.")
-    if detail is None or not (detail.delivery_location or "").strip():
-        errors.append("Set a delivery location in Delivery details.")
+    if detail is None or (detail.pickup_time or "") not in PICKUP_TIME_OPTIONS:
+        errors.append("Select a pickup time in Pickup details.")
+    elif detail.pickup_time == PICKUP_TIME_OTHER and not (detail.additional_notes or "").strip():
+        errors.append(
+            "Add your preferred pickup date/time to Additional notes — "
+            "required when the 'Other' pickup option is selected."
+        )
 
     for line in sorted(work_item.lines, key=lambda l: l.line_number):
         d = line.supply_detail

--- a/app/routes/work/supply/order.py
+++ b/app/routes/work/supply/order.py
@@ -1,6 +1,6 @@
 """
 Supply order creation — starting a new draft supply order (the cart) —
-plus cart-editing routes (line update/delete, delivery details save).
+plus cart-editing routes (line update/delete, pickup details save).
 
 Supply is a repeat-ordering work type: every order is PRIMARY and a
 department can place unlimited independent orders per event, so creation
@@ -8,8 +8,6 @@ is gated on require_portfolio_edit + can_edit rather than the engine's
 perms.can_create_primary (which locks after the first PRIMARY exists per
 portfolio — see the matching comment in portfolio.py).
 """
-from datetime import datetime
-
 from flask import abort, flash, redirect, request, url_for
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -32,6 +30,7 @@ from ..helpers import (
     require_portfolio_edit,
     require_work_item_view,
 )
+from .form_utils import PICKUP_TIME_OPTIONS
 
 
 def _load_order(event: str, dept: str, public_id: str):
@@ -39,7 +38,7 @@ def _load_order(event: str, dept: str, public_id: str):
 
     Mirrors catalog.py's _load_order gate idiom so 404/permission behavior
     stays identical across the cab; also eager-loads the order-level
-    delivery detail for the details-save route.
+    pickup detail for the details-save route.
     """
     ctx = get_portfolio_context(event, dept, "supply")
 
@@ -202,7 +201,7 @@ def supply_line_delete(event: str, dept: str, public_id: str, line_number: int):
 
 @work_bp.post("/<event>/<dept>/supply/order/<public_id>/details")
 def supply_order_details_save(event: str, dept: str, public_id: str):
-    """Save order-level delivery details (needed-by date, location, notes)."""
+    """Save order-level pickup details (pickup time, notes)."""
     work_item, ctx, perms = _load_order(event, dept, public_id)
     detail_url = url_for(
         "work.supply_order_detail", event=event, dept=dept, public_id=public_id,
@@ -211,16 +210,13 @@ def supply_order_details_save(event: str, dept: str, public_id: str):
     if not perms.can_edit:
         abort(403, "You do not have permission to edit this supply order.")
 
-    needed_by_str = (request.form.get("needed_by_date") or "").strip()
-    needed_by_date = None
-    if needed_by_str:
-        try:
-            needed_by_date = datetime.strptime(needed_by_str, "%Y-%m-%d").date()
-        except ValueError:
-            flash("Needed-by date must be a valid date (YYYY-MM-DD).", "error")
-            return redirect(detail_url)
+    # Empty is allowed while drafting; submit validation enforces a choice.
+    # Anything non-empty must be a known option (form tampering guard).
+    pickup_time = (request.form.get("pickup_time") or "").strip()
+    if pickup_time and pickup_time not in PICKUP_TIME_OPTIONS:
+        flash("Choose a pickup time from the list.", "error")
+        return redirect(detail_url)
 
-    delivery_location = (request.form.get("delivery_location") or "").strip()
     additional_notes = (
         request.form.get("additional_notes", "").replace("\r\n", "\n").strip()
     )
@@ -228,20 +224,17 @@ def supply_order_details_save(event: str, dept: str, public_id: str):
     user_ctx = get_user_ctx()
     order_detail = work_item.supply_order_detail
     if order_detail is None:
-        # Defensive: supply_order_new always creates one, but don't 500 if
-        # it's somehow missing.
         order_detail = SupplyOrderDetail(
             work_item_id=work_item.id,
             created_by_user_id=user_ctx.user_id,
         )
         db.session.add(order_detail)
 
-    order_detail.needed_by_date = needed_by_date
-    order_detail.delivery_location = delivery_location or None
+    order_detail.pickup_time = pickup_time or None
     order_detail.additional_notes = additional_notes or None
     order_detail.updated_by_user_id = user_ctx.user_id
 
     db.session.commit()
 
-    flash("Delivery details saved.", "success")
+    flash("Pickup details saved.", "success")
     return redirect(detail_url)

--- a/app/routes/work/supply/view.py
+++ b/app/routes/work/supply/view.py
@@ -31,7 +31,7 @@ from ..helpers import (
     get_unified_audit_events,
     require_work_item_view,
 )
-from .form_utils import validate_order_for_submit
+from .form_utils import PICKUP_TIME_OPTIONS, validate_order_for_submit
 from .order import is_line_kickback_editable
 
 
@@ -142,6 +142,7 @@ def supply_order_detail(event: str, dept: str, public_id: str):
         perms=perms,
         work_item=work_item,
         order_detail=work_item.supply_order_detail,
+        pickup_time_options=PICKUP_TIME_OPTIONS,
         lines=lines,
         can_edit=can_edit,
         kickback_editable_line_numbers=kickback_editable_line_numbers,

--- a/app/templates/supply/admin_finalize.html
+++ b/app/templates/supply/admin_finalize.html
@@ -19,8 +19,8 @@
       <h1 style="margin:0;">Finalize {{ work_item.public_id }}</h1>
       <div class="muted" style="margin-top:4px;">
         {{ department.name }} &middot; {{ event_cycle.name }}
-        {% if order_detail and order_detail.needed_by_date %}
-          &middot; needed by {{ order_detail.needed_by_date.strftime('%Y-%m-%d') }}
+        {% if order_detail and order_detail.pickup_time %}
+          &middot; pickup: {{ order_detail.pickup_time }}
         {% endif %}
       </div>
     </div>
@@ -29,10 +29,10 @@
     </div>
   </div>
 
-  {# Order delivery context #}
+  {# Order pickup context #}
   <section class="card">
-    <div class="meta"><strong>Delivery location:</strong>
-      {{ order_detail.delivery_location if order_detail and order_detail.delivery_location else '-' }}
+    <div class="meta"><strong>Pickup time:</strong>
+      {{ order_detail.pickup_time if order_detail and order_detail.pickup_time else '-' }}
     </div>
     {% if order_detail and order_detail.additional_notes %}
       <div class="meta" style="margin-top: 8px;">

--- a/app/templates/supply/admin_queue.html
+++ b/app/templates/supply/admin_queue.html
@@ -1,5 +1,5 @@
 {# templates/supply/admin_queue.html #}
-{# FestOps finalize queue: SUBMITTED supply orders sorted soonest-needed
+{# FestOps finalize queue: SUBMITTED supply orders sorted oldest-submitted
    first, with per-order APPROVAL_GROUP review progress and a ready-to-
    finalize badge when every line has a terminal decision. Literal-URL
    admin route (app/routes/work/supply/admin.py) — no event/dept in path. #}
@@ -26,7 +26,7 @@
           <tr>
             <th style="width: 180px;">Order</th>
             <th>Department</th>
-            <th style="width: 130px;">Needed by</th>
+            <th style="width: 220px;">Pickup time</th>
             <th style="width: 110px;" class="right">Progress</th>
             <th style="width: 150px;">Status</th>
             <th style="width: 100px;"></th>
@@ -45,9 +45,9 @@
                 {{ row.department.name }}
                 <div class="muted small">{{ row.event_cycle.name }}</div>
               </td>
-              <td data-label="Needed by">
-                {% if row.needed_by %}
-                  {{ row.needed_by.strftime('%Y-%m-%d') }}
+              <td data-label="Pickup time">
+                {% if row.pickup_time %}
+                  {{ row.pickup_time }}
                 {% else %}
                   <span class="muted small">-</span>
                 {% endif %}

--- a/app/templates/supply/all_orders.html
+++ b/app/templates/supply/all_orders.html
@@ -89,7 +89,7 @@
             <th style="width: 110px;">Status</th>
             <th style="width: 70px;" class="right">Lines</th>
             <th>Item mix</th>
-            <th style="width: 110px;">Needed by</th>
+            <th style="width: 200px;">Pickup time</th>
             <th style="width: 140px;">Updated</th>
             <th style="width: 80px;"></th>
           </tr>
@@ -129,12 +129,8 @@
                   <span class="muted small">-</span>
                 {% endif %}
               </td>
-              <td data-label="Needed by" class="muted small">
-                {% if row.needed_by %}
-                  {{ row.needed_by.strftime('%Y-%m-%d') }}
-                {% else %}
-                  -
-                {% endif %}
+              <td data-label="Pickup time" class="muted small">
+                {{ row.pickup_time if row.pickup_time else '-' }}
               </td>
               <td data-label="Updated" class="muted small">
                 {% if wi.updated_at %}

--- a/app/templates/supply/catalog.html
+++ b/app/templates/supply/catalog.html
@@ -90,6 +90,16 @@
               {% if not item.is_expendable %}
                 <span class="pill pill-info">Must be returned</span>
               {% endif %}
+              {% set cart_entry = in_cart.get(item.id) %}
+              {% if cart_entry %}
+                <span class="pill">
+                  {%- if cart_entry.lines == 1 -%}
+                    In order ×{{ cart_entry.qty }}
+                  {%- else -%}
+                    In order: {{ cart_entry.lines }} lines · qty {{ cart_entry.qty }}
+                  {%- endif -%}
+                </span>
+              {% endif %}
             </div>
             {% if can_add %}
               <form method="post" action="{{ url_for('work.supply_line_add', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id) }}" style="margin-top: 8px;">
@@ -141,6 +151,16 @@
                   {% endif %}
                   {% if not item.is_expendable %}
                     <span class="pill pill-info">Must be returned</span>
+                  {% endif %}
+                  {% set cart_entry = in_cart.get(item.id) %}
+                  {% if cart_entry %}
+                    <span class="pill">
+                      {%- if cart_entry.lines == 1 -%}
+                        In order ×{{ cart_entry.qty }}
+                      {%- else -%}
+                        In order: {{ cart_entry.lines }} lines · qty {{ cart_entry.qty }}
+                      {%- endif -%}
+                    </span>
                   {% endif %}
                 </div>
                 {% if item.notes %}

--- a/app/templates/supply/line_review.html
+++ b/app/templates/supply/line_review.html
@@ -96,12 +96,9 @@
         <h3 style="margin:0 0 12px 0;">Order Details</h3>
 
         <div class="meta">
-          <div><strong>Needed by:</strong>
-            {{ order_detail.needed_by_date.strftime('%Y-%m-%d') if order_detail and order_detail.needed_by_date else '-' }}
+          <div><strong>Pickup time:</strong>
+            {{ order_detail.pickup_time if order_detail and order_detail.pickup_time else '-' }}
           </div>
-        </div>
-        <div class="meta" style="margin-top: 8px;">
-          <div><strong>Delivery location:</strong> {{ order_detail.delivery_location if order_detail and order_detail.delivery_location else '-' }}</div>
         </div>
         {% if order_detail and order_detail.additional_notes %}
           <div class="meta" style="margin-top: 8px;">

--- a/app/templates/supply/order_detail.html
+++ b/app/templates/supply/order_detail.html
@@ -172,42 +172,44 @@
     {% endif %}
   </section>
 
-  {# Delivery details #}
+  {# Pickup details #}
   <section class="card" style="margin-bottom: 16px;">
     <div class="muted small" style="text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 8px;">
-      Delivery Details
+      Pickup Details
     </div>
     {% if can_edit %}
       <form method="post"
             action="{{ url_for('work.supply_order_details_save', event=ctx.event_cycle.code, dept=ctx.department.code, public_id=work_item.public_id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <label class="form-label small">Needed by
-          <input type="date" name="needed_by_date"
-                 value="{{ order_detail.needed_by_date.strftime('%Y-%m-%d') if order_detail and order_detail.needed_by_date else '' }}">
+        <label class="form-label small">Pickup time
+          <select name="pickup_time">
+            <option value="">(Select Pickup Time)</option>
+            {% for option in pickup_time_options %}
+              <option value="{{ option }}"
+                      {% if order_detail and order_detail.pickup_time == option %}selected{% endif %}>
+                {{ option }}
+              </option>
+            {% endfor %}
+          </select>
         </label>
-        <label class="form-label small">Delivery location
-          <input type="text" name="delivery_location"
-                 value="{{ order_detail.delivery_location if order_detail and order_detail.delivery_location else '' }}"
-                 placeholder="e.g. Warehouse dock B">
-        </label>
+        <div class="muted small" style="margin-bottom: 8px;">
+          Pickup location will be communicated before the event.
+        </div>
         <label class="form-label small">Additional notes
           <textarea name="additional_notes" rows="3" style="width:100%;">{{ order_detail.additional_notes if order_detail and order_detail.additional_notes else '' }}</textarea>
         </label>
-        <button type="submit" class="btn btn-primary" style="margin-top: 8px;">Save delivery details</button>
+        <button type="submit" class="btn btn-primary" style="margin-top: 8px;">Save pickup details</button>
       </form>
     {% elif order_detail %}
       <div style="margin-bottom: 4px;">
-        <strong>Needed by:</strong>
-        {% if order_detail.needed_by_date %}
-          {{ order_detail.needed_by_date.strftime('%Y-%m-%d') }}
+        <strong>Pickup time:</strong>
+        {% if order_detail.pickup_time %}
+          {{ order_detail.pickup_time }}
         {% else %}
           <span class="muted">Not set</span>
         {% endif %}
       </div>
-      <div style="margin-bottom: 4px;">
-        <strong>Delivery location:</strong>
-        {{ order_detail.delivery_location or '-' }}
-      </div>
+      <div class="muted small">Pickup location will be communicated before the event.</div>
       {% if order_detail.additional_notes %}
         <div style="margin-top: 8px;">
           <strong>Additional notes:</strong>
@@ -215,7 +217,7 @@
         </div>
       {% endif %}
     {% else %}
-      <div class="muted">No delivery details set yet.</div>
+      <div class="muted">No pickup details set yet.</div>
     {% endif %}
   </section>
 

--- a/app/templates/supply/portfolio_landing.html
+++ b/app/templates/supply/portfolio_landing.html
@@ -69,7 +69,7 @@
         {% set line_count = item_line_counts.get(item.id, 0) %}
         {% set status = line_summary.effective_status | upper if line_summary else item.status | upper %}
         {% set status_label = friendly_status(status) if friendly_status else status %}
-        {% set needed_by = item.supply_order_detail.needed_by_date if item.supply_order_detail else none %}
+        {% set pickup_time = item.supply_order_detail.pickup_time if item.supply_order_detail else none %}
 
         <div class="card" style="margin-bottom: 12px;">
           <div style="display:flex; justify-content:space-between; gap:12px; align-items:flex-start;">
@@ -88,8 +88,8 @@
                 {% else %}
                   Created {{ item.created_at.strftime('%b %d, %Y') }}
                 {% endif %}
-                {% if needed_by %}
-                  &middot; Needed by {{ needed_by.strftime('%b %d, %Y') }}
+                {% if pickup_time %}
+                  &middot; Pickup: {{ pickup_time }}
                 {% endif %}
               </div>
             </div>

--- a/migrations/versions/q9w4e7r2t5y8_supply_pickup_time.py
+++ b/migrations/versions/q9w4e7r2t5y8_supply_pickup_time.py
@@ -1,0 +1,37 @@
+"""Supply: pickup_time replaces needed_by_date + delivery_location
+
+Departments pick orders up from a staging location (communicated before
+the event) — they are not delivered. The requester now picks a pickup
+slot from a hardcoded list; the display string is stored as a snapshot.
+
+Data loss note: existing staging/dev orders lose their delivery details.
+Accepted — no prod deployment of SUPPLY exists yet.
+
+Revision ID: q9w4e7r2t5y8
+Revises: p3r8t2v7w4x9
+Create Date: 2026-07-08
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'q9w4e7r2t5y8'
+down_revision = 'p3r8t2v7w4x9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('supply_order_details', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('pickup_time', sa.String(length=120), nullable=True))
+        batch_op.drop_column('delivery_location')
+        batch_op.drop_column('needed_by_date')
+
+
+def downgrade():
+    with op.batch_alter_table('supply_order_details', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('needed_by_date', sa.Date(), nullable=True))
+        batch_op.add_column(sa.Column('delivery_location', sa.String(length=256), nullable=True))
+        batch_op.drop_column('pickup_time')

--- a/migrations/versions/r5t9w2x6y3z8_supply_clean_junk_strings.py
+++ b/migrations/versions/r5t9w2x6y3z8_supply_clean_junk_strings.py
@@ -1,0 +1,34 @@
+"""Null out junk placeholder strings in supply_items text columns
+
+Earlier CSV imports stored blank cells as literal 'None'/'nan' strings
+(visible under the catalog qty inputs). The parser is hardened as of
+this release; this cleans rows imported before the fix.
+
+Revision ID: r5t9w2x6y3z8
+Revises: q9w4e7r2t5y8
+Create Date: 2026-07-08
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'r5t9w2x6y3z8'
+down_revision = 'q9w4e7r2t5y8'
+branch_labels = None
+depends_on = None
+
+_COLUMNS = ("notes", "order_guidance", "location_zone", "bin_location")
+
+
+def upgrade():
+    for column in _COLUMNS:
+        op.execute(
+            f"UPDATE supply_items SET {column} = NULL "
+            f"WHERE lower(trim({column})) IN ('none', 'nan', 'null')"
+        )
+
+
+def downgrade():
+    # Data cleanup only — nothing sensible to restore.
+    pass

--- a/tests/integration/test_supply_admin_final.py
+++ b/tests/integration/test_supply_admin_final.py
@@ -399,6 +399,9 @@ class TestSupplyAllOrdersAdminView:
         resp = client.get("/admin/supply/orders/")
         assert resp.status_code == 200
         assert work_item.public_id.encode() in resp.data
+        # Rows are dicts: a renamed key would render as a silent "-" (Jinja
+        # Undefined is falsy), so pin the real pickup string.
+        assert PICKUP_TIME_OPTIONS[0].encode() in resp.data
 
     def test_supply_all_orders_forbidden_for_non_admin(self, app, client, seed_workflow_data):
         _seed_supply(seed_workflow_data)
@@ -406,6 +409,34 @@ class TestSupplyAllOrdersAdminView:
         _login(client, "test:reviewer")
         resp = client.get("/admin/supply/orders/")
         assert resp.status_code == 403
+
+
+class TestSupplyAdminQueueView:
+    """GET /admin/supply/queue/ — the FestOps finalize queue table."""
+
+    def test_queue_renders_pickup_time_for_submitted_order(
+        self, app, client, seed_workflow_data
+    ):
+        """Rows are dicts: a renamed key would render as a silent "-" (Jinja
+        Undefined is falsy), so pin the real pickup string in the response."""
+        wt = _seed_supply(seed_workflow_data)
+        cycle = seed_workflow_data["cycle"]
+        dept = seed_workflow_data["department"]
+        group = _seed_approval_group(wt)
+        category = _seed_category(approval_group=group)
+        item = _seed_item(category, unit_cost_cents=500)
+
+        work_item = _make_draft_order(wt, cycle, dept)
+        _add_line(work_item, item, quantity=3, line_number=1)
+        _set_pickup_details(work_item)
+
+        _login(client, "test:admin")
+        _submit(client, cycle, dept, work_item)
+
+        resp = client.get("/admin/supply/queue/")
+        assert resp.status_code == 200
+        assert work_item.public_id.encode() in resp.data
+        assert PICKUP_TIME_OPTIONS[0].encode() in resp.data
 
 
 class TestBuildAdminQueuesIsBudgetScoped:

--- a/tests/integration/test_supply_admin_final.py
+++ b/tests/integration/test_supply_admin_final.py
@@ -15,8 +15,6 @@ The three tests pin:
   3. a line still PENDING at APPROVAL_GROUP auto-approves at its requested
      quantity when finalized (BUDGET auto-approve semantics = the qty default).
 """
-from datetime import date
-
 from app import db
 from app.models import (
     ApprovalGroup,
@@ -42,6 +40,7 @@ from app.models import (
     WORK_LINE_STATUS_APPROVED,
     WORK_LINE_STATUS_REJECTED,
 )
+from app.routes.work.supply.form_utils import PICKUP_TIME_OPTIONS
 
 
 def _login(client, user_id):
@@ -152,10 +151,10 @@ def _add_line(work_item, item, quantity=1, notes=None, line_number=None):
     return line
 
 
-def _set_delivery_details(work_item, needed_by=date(2027, 1, 10), location="Warehouse dock B"):
+def _set_pickup_details(work_item, pickup_time=PICKUP_TIME_OPTIONS[0], notes=None):
     detail = work_item.supply_order_detail
-    detail.needed_by_date = needed_by
-    detail.delivery_location = location
+    detail.pickup_time = pickup_time
+    detail.additional_notes = notes
     db.session.commit()
 
 
@@ -194,7 +193,7 @@ class TestSupplyFinalizeWritesQuantities:
         work_item = _make_draft_order(wt, cycle, dept)
         line1 = _add_line(work_item, item, quantity=5, notes="keep", line_number=1)
         line2 = _add_line(work_item, item, quantity=5, notes="drop", line_number=2)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         _submit(client, cycle, dept, work_item)
@@ -259,7 +258,7 @@ class TestSupplyFinalizeOverrideNeedsNote:
 
         work_item = _make_draft_order(wt, cycle, dept)
         line1 = _add_line(work_item, item, quantity=4, line_number=1)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         _submit(client, cycle, dept, work_item)
@@ -297,7 +296,7 @@ class TestSupplyFinalizeAutoApprovesPending:
 
         work_item = _make_draft_order(wt, cycle, dept)
         line1 = _add_line(work_item, item, quantity=7, line_number=1)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         _submit(client, cycle, dept, work_item)
@@ -341,7 +340,7 @@ class TestSupplyFinalizeBlocksOnKickback:
         work_item = _make_draft_order(wt, cycle, dept)
         line1 = _add_line(work_item, item, quantity=5, line_number=1)
         line2 = _add_line(work_item, item, quantity=3, line_number=2)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         _submit(client, cycle, dept, work_item)
@@ -392,7 +391,7 @@ class TestSupplyAllOrdersAdminView:
 
         work_item = _make_draft_order(wt, cycle, dept)
         _add_line(work_item, item, quantity=3, line_number=1)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         _submit(client, cycle, dept, work_item)
@@ -431,7 +430,7 @@ class TestBuildAdminQueuesIsBudgetScoped:
 
         work_item = _make_draft_order(wt, cycle, dept)
         line1 = _add_line(work_item, item, quantity=3, line_number=1)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         _submit(client, cycle, dept, work_item)
@@ -453,7 +452,7 @@ class TestBuildAdminQueuesIsBudgetScoped:
 
         work_item = _make_draft_order(wt, cycle, dept)
         _add_line(work_item, item, quantity=3, line_number=1)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         _submit(client, cycle, dept, work_item)
@@ -480,7 +479,7 @@ class TestBuildAdminQueuesIsBudgetScoped:
 
         work_item = _make_draft_order(wt, cycle, dept)
         line1 = _add_line(work_item, item, quantity=3, line_number=1)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         _submit(client, cycle, dept, work_item)

--- a/tests/integration/test_supply_review.py
+++ b/tests/integration/test_supply_review.py
@@ -14,8 +14,6 @@ when config.has_admin_final is True). Task 11's tests pinned the same flag
 combo at submit time; this pins it at the "last line decided" trigger point
 inside apply_review_decision.
 """
-from datetime import date
-
 from app import db
 from app.models import (
     ApprovalGroup,
@@ -39,6 +37,7 @@ from app.models import (
     ROUTING_STRATEGY_CATEGORY,
     WORK_ITEM_STATUS_SUBMITTED,
 )
+from app.routes.work.supply.form_utils import PICKUP_TIME_OPTIONS
 
 
 def _login(client, user_id):
@@ -155,10 +154,10 @@ def _add_line(work_item, item, quantity=1, notes=None, line_number=None):
     return line
 
 
-def _set_delivery_details(work_item, needed_by=date(2027, 1, 10), location="Warehouse dock B"):
+def _set_pickup_details(work_item, pickup_time=PICKUP_TIME_OPTIONS[0], notes=None):
     detail = work_item.supply_order_detail
-    detail.needed_by_date = needed_by
-    detail.delivery_location = location
+    detail.pickup_time = pickup_time
+    detail.additional_notes = notes
     db.session.commit()
 
 
@@ -187,7 +186,7 @@ def _setup_submitted_order(app, client, seed_workflow_data, quantity=2, notes="f
 
     work_item = _make_draft_order(wt, cycle, dept)
     line = _add_line(work_item, item, quantity=quantity, notes=notes)
-    _set_delivery_details(work_item)
+    _set_pickup_details(work_item)
 
     _seed_reviewer(seed_workflow_data, group)
 

--- a/tests/integration/test_supply_routes.py
+++ b/tests/integration/test_supply_routes.py
@@ -250,7 +250,7 @@ class TestSupplyOrderDetail(object):
         self, app, client, seed_workflow_data
     ):
         """A DRAFT order with can_edit renders per-row Save/Remove forms
-        and a delivery-details form (Task 10 template widgets)."""
+        and a pickup-details form (Task 10 template widgets)."""
         wt = _seed_supply(seed_workflow_data)
         cycle = seed_workflow_data["cycle"]
         dept = seed_workflow_data["department"]
@@ -266,13 +266,13 @@ class TestSupplyOrderDetail(object):
         assert response.status_code == 200
         assert b"Save" in response.data
         assert b"Remove" in response.data
-        assert b'type="date" name="needed_by_date"' in response.data
-        assert b"Save delivery details" in response.data
+        assert b'<select name="pickup_time">' in response.data
+        assert b"Save pickup details" in response.data
 
     def test_submitted_order_detail_renders_read_only(
         self, app, client, seed_workflow_data
     ):
-        """A non-DRAFT order renders the cart/delivery details read-only —
+        """A non-DRAFT order renders the cart/pickup details read-only —
         no edit widgets."""
         wt = _seed_supply(seed_workflow_data)
         cycle = seed_workflow_data["cycle"]
@@ -289,8 +289,8 @@ class TestSupplyOrderDetail(object):
         )
 
         assert response.status_code == 200
-        assert b"Save delivery details" not in response.data
-        assert b'type="date" name="needed_by_date"' not in response.data
+        assert b"Save pickup details" not in response.data
+        assert b'<select name="pickup_time">' not in response.data
 
     def test_kicked_back_line_reopens_edit_form_on_submitted_order(
         self, app, client, seed_workflow_data
@@ -661,7 +661,7 @@ class TestSupplyLineDelete(object):
 class TestSupplyOrderDetailsSave(object):
     """POST /<event>/<dept>/supply/order/<public_id>/details"""
 
-    def test_details_save_persists_needed_by_and_location(self, app, client, seed_workflow_data):
+    def test_details_save_persists_pickup_time(self, app, client, seed_workflow_data):
         wt = _seed_supply(seed_workflow_data)
         cycle = seed_workflow_data["cycle"]
         dept = seed_workflow_data["department"]
@@ -671,16 +671,31 @@ class TestSupplyOrderDetailsSave(object):
         response = client.post(
             f"/{cycle.code}/{dept.code}/supply/order/{work_item.public_id}/details",
             data={
-                "needed_by_date": "2027-01-10",
-                "delivery_location": "Warehouse dock B",
+                "pickup_time": "Tuesday Evening (after 6 PM)",
                 "additional_notes": "",
             },
         )
 
         assert response.status_code == 302
         order_detail = SupplyOrderDetail.query.filter_by(work_item_id=work_item.id).first()
-        assert order_detail.needed_by_date.isoformat() == "2027-01-10"
-        assert order_detail.delivery_location == "Warehouse dock B"
+        assert order_detail.pickup_time == "Tuesday Evening (after 6 PM)"
+
+    def test_details_save_rejects_unknown_pickup_time(self, app, client, seed_workflow_data):
+        """Values outside PICKUP_TIME_OPTIONS are a form-tampering guard."""
+        wt = _seed_supply(seed_workflow_data)
+        cycle = seed_workflow_data["cycle"]
+        dept = seed_workflow_data["department"]
+        work_item = _make_draft_order(wt, cycle, dept)
+
+        _login(client, "test:admin")
+        response = client.post(
+            f"/{cycle.code}/{dept.code}/supply/order/{work_item.public_id}/details",
+            data={"pickup_time": "Whenever I feel like it", "additional_notes": ""},
+        )
+
+        assert response.status_code == 302
+        order_detail = SupplyOrderDetail.query.filter_by(work_item_id=work_item.id).first()
+        assert order_detail.pickup_time is None
 
 
 class TestSupplyEndpointReferences:

--- a/tests/integration/test_supply_routes.py
+++ b/tests/integration/test_supply_routes.py
@@ -386,6 +386,84 @@ class TestSupplyCatalog:
     """GET/POST /<event>/<dept>/supply/order/<public_id>/catalog and
     .../lines/add — browsing the item catalog and adding to the cart."""
 
+    def test_catalog_shows_in_cart_badge_single_line(
+        self, app, client, seed_workflow_data
+    ):
+        """An item already in the cart shows 'In order ×<qty>' on its row."""
+        wt = _seed_supply(seed_workflow_data)
+        cycle = seed_workflow_data["cycle"]
+        dept = seed_workflow_data["department"]
+        work_item = _make_draft_order(wt, cycle, dept)
+        category, popular_item, plain_item = _seed_catalog()
+        _add_line(work_item, plain_item, quantity=12, notes="to power things")
+
+        _login(client, "test:admin")
+        response = client.get(
+            f"/{cycle.code}/{dept.code}/supply/order/{work_item.public_id}/catalog"
+        )
+
+        assert response.status_code == 200
+        assert "In order ×12".encode("utf-8") in response.data
+
+    def test_catalog_shows_lines_and_qty_for_multiple_lines(
+        self, app, client, seed_workflow_data
+    ):
+        """Duplicate adds are separate lines; the badge sums them."""
+        wt = _seed_supply(seed_workflow_data)
+        cycle = seed_workflow_data["cycle"]
+        dept = seed_workflow_data["department"]
+        work_item = _make_draft_order(wt, cycle, dept)
+        category, popular_item, plain_item = _seed_catalog()
+        _add_line(work_item, plain_item, quantity=1, notes="tech booth", line_number=1)
+        _add_line(work_item, plain_item, quantity=12, notes="registration", line_number=2)
+
+        _login(client, "test:admin")
+        response = client.get(
+            f"/{cycle.code}/{dept.code}/supply/order/{work_item.public_id}/catalog"
+        )
+
+        assert response.status_code == 200
+        assert b"2 lines" in response.data
+        assert b"qty 13" in response.data
+
+    def test_catalog_no_badge_when_item_not_in_cart(
+        self, app, client, seed_workflow_data
+    ):
+        wt = _seed_supply(seed_workflow_data)
+        cycle = seed_workflow_data["cycle"]
+        dept = seed_workflow_data["department"]
+        work_item = _make_draft_order(wt, cycle, dept)
+        _seed_catalog()
+
+        _login(client, "test:admin")
+        response = client.get(
+            f"/{cycle.code}/{dept.code}/supply/order/{work_item.public_id}/catalog"
+        )
+
+        assert response.status_code == 200
+        assert b"In order" not in response.data
+
+    def test_catalog_badge_renders_in_both_layouts_for_popular_item(
+        self, app, client, seed_workflow_data
+    ):
+        """A popular item renders in the popular-cards strip AND its dense
+        category row; the (duplicated) badge block must render in both, so
+        an edit to only one copy is caught."""
+        wt = _seed_supply(seed_workflow_data)
+        cycle = seed_workflow_data["cycle"]
+        dept = seed_workflow_data["department"]
+        work_item = _make_draft_order(wt, cycle, dept)
+        category, popular_item, plain_item = _seed_catalog()
+        _add_line(work_item, popular_item, quantity=5, notes="for panels")
+
+        _login(client, "test:admin")
+        response = client.get(
+            f"/{cycle.code}/{dept.code}/supply/order/{work_item.public_id}/catalog"
+        )
+
+        assert response.status_code == 200
+        assert response.data.count("In order ×5".encode("utf-8")) == 2
+
     def test_catalog_renders_item_category_and_popular(
         self, app, client, seed_workflow_data
     ):

--- a/tests/integration/test_supply_submit.py
+++ b/tests/integration/test_supply_submit.py
@@ -13,8 +13,6 @@ Harness mirrors tests/integration/test_supply_routes.py's _seed_supply
 helper, extended with SUPPLY-scoped approval groups and a category mapped
 to one of them (the routing dependency submit needs).
 """
-from datetime import date
-
 from app import db
 from app.models import (
     ApprovalGroup,
@@ -35,6 +33,7 @@ from app.models import (
     WORK_ITEM_STATUS_DRAFT,
     WORK_ITEM_STATUS_SUBMITTED,
 )
+from app.routes.work.supply.form_utils import PICKUP_TIME_OPTIONS, PICKUP_TIME_OTHER
 
 
 def _login(client, user_id):
@@ -149,10 +148,10 @@ def _add_line(work_item, item, quantity=1, notes=None, line_number=None):
     return line
 
 
-def _set_delivery_details(work_item, needed_by=date(2027, 1, 10), location="Warehouse dock B"):
+def _set_pickup_details(work_item, pickup_time=PICKUP_TIME_OPTIONS[0], notes=None):
     detail = work_item.supply_order_detail
-    detail.needed_by_date = needed_by
-    detail.delivery_location = location
+    detail.pickup_time = pickup_time
+    detail.additional_notes = notes
     db.session.commit()
 
 
@@ -170,7 +169,7 @@ class TestSupplySubmitAutoRoutes:
 
         work_item = _make_draft_order(wt, cycle, dept)
         line = _add_line(work_item, item, quantity=2, notes="for tech booth")
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         response = client.post(
@@ -208,7 +207,7 @@ class TestSupplySubmitValidationBlocks:
         cycle = seed_workflow_data["cycle"]
         dept = seed_workflow_data["department"]
         work_item = _make_draft_order(wt, cycle, dept)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         response = self._submit(client, cycle, dept, work_item)
@@ -217,7 +216,7 @@ class TestSupplySubmitValidationBlocks:
         db.session.refresh(work_item)
         assert work_item.status == WORK_ITEM_STATUS_DRAFT
 
-    def test_missing_needed_by_date_blocks_submit(self, app, client, seed_workflow_data):
+    def test_missing_pickup_time_blocks_submit(self, app, client, seed_workflow_data):
         wt = _seed_supply(seed_workflow_data)
         cycle = seed_workflow_data["cycle"]
         dept = seed_workflow_data["department"]
@@ -226,7 +225,7 @@ class TestSupplySubmitValidationBlocks:
         item = _seed_item(category)
         work_item = _make_draft_order(wt, cycle, dept)
         _add_line(work_item, item)
-        # No delivery details set — needed_by_date is None.
+        # No pickup details set — pickup_time is None.
 
         _login(client, "test:admin")
         response = self._submit(client, cycle, dept, work_item)
@@ -244,7 +243,7 @@ class TestSupplySubmitValidationBlocks:
         item = _seed_item(category, name="Special Order Widget", notes_required=True)
         work_item = _make_draft_order(wt, cycle, dept)
         _add_line(work_item, item, notes=None)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         response = self._submit(client, cycle, dept, work_item)
@@ -263,7 +262,7 @@ class TestSupplySubmitValidationBlocks:
         item = _seed_item(category)
         work_item = _make_draft_order(wt, cycle, dept)
         _add_line(work_item, item)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         _login(client, "test:admin")
         response = self._submit(client, cycle, dept, work_item)
@@ -273,6 +272,46 @@ class TestSupplySubmitValidationBlocks:
         assert work_item.status == WORK_ITEM_STATUS_DRAFT
         # No review rows should have been created for the unroutable line.
         assert WorkLineReview.query.count() == 0
+
+    def test_other_pickup_without_notes_blocks_submit(self, app, client, seed_workflow_data):
+        """'Other' pickup requires the preferred date/time in notes."""
+        wt = _seed_supply(seed_workflow_data)
+        cycle = seed_workflow_data["cycle"]
+        dept = seed_workflow_data["department"]
+        group = _seed_approval_group(wt)
+        category = _seed_category(approval_group=group)
+        item = _seed_item(category)
+        work_item = _make_draft_order(wt, cycle, dept)
+        _add_line(work_item, item)
+        _set_pickup_details(work_item, pickup_time=PICKUP_TIME_OTHER, notes=None)
+
+        _login(client, "test:admin")
+        response = self._submit(client, cycle, dept, work_item)
+
+        assert response.status_code == 302
+        db.session.refresh(work_item)
+        assert work_item.status == WORK_ITEM_STATUS_DRAFT
+
+    def test_other_pickup_with_notes_submits(self, app, client, seed_workflow_data):
+        wt = _seed_supply(seed_workflow_data)
+        cycle = seed_workflow_data["cycle"]
+        dept = seed_workflow_data["department"]
+        group = _seed_approval_group(wt)
+        category = _seed_category(approval_group=group)
+        item = _seed_item(category)
+        work_item = _make_draft_order(wt, cycle, dept)
+        _add_line(work_item, item, notes="for tech booth")
+        _set_pickup_details(
+            work_item, pickup_time=PICKUP_TIME_OTHER,
+            notes="Friday 10 AM if possible",
+        )
+
+        _login(client, "test:admin")
+        response = self._submit(client, cycle, dept, work_item)
+
+        assert response.status_code == 302
+        db.session.refresh(work_item)
+        assert work_item.status == WORK_ITEM_STATUS_SUBMITTED
 
 
 class TestSupplySubmitDeactivatedItem:
@@ -285,7 +324,7 @@ class TestSupplySubmitDeactivatedItem:
         item = _seed_item(category, name="Discontinued Gizmo")
         work_item = _make_draft_order(wt, cycle, dept)
         _add_line(work_item, item)
-        _set_delivery_details(work_item)
+        _set_pickup_details(work_item)
 
         item.is_active = False
         db.session.commit()

--- a/tests/unit/test_supply_import.py
+++ b/tests/unit/test_supply_import.py
@@ -269,3 +269,35 @@ def test_parse_rejects_missing_headers(app, import_seed):
 
     with pytest.raises(ImportParseError):
         parse_catalog_upload(upload)
+
+
+def test_clean_text_treats_junk_placeholder_strings_as_blank():
+    """Blank CSV cells round-tripped through pandas/str() can arrive as
+    'None'/'nan'; they must not be stored as literal guidance text
+    (they rendered as visible 'None' under the catalog qty inputs)."""
+    from app.routes.admin.supply_import_utils import _clean_text
+
+    assert _clean_text("None") is None
+    assert _clean_text(" nan ") is None
+    assert _clean_text("NULL") is None
+    assert _clean_text("none") is None
+
+
+def test_clean_text_keeps_real_values_containing_junk_tokens():
+    from app.routes.admin.supply_import_utils import _clean_text
+
+    assert _clean_text("Nonesuch brand tape") == "Nonesuch brand tape"
+    assert _clean_text("0") == "0"
+
+
+def test_parse_bool_and_int_stay_loud_for_junk_tokens():
+    """Junk tokens are blank ONLY for free-text columns; in boolean or
+    numeric columns they must still raise a loud import problem, not
+    silently coerce to the default/NULL."""
+    from app.routes.admin.supply_import_utils import _clean_str, _parse_bool, _parse_int
+
+    assert _clean_str("None") == "None"  # no junk handling here
+    with pytest.raises(ValueError):
+        _parse_bool("none", default=False)
+    with pytest.raises(ValueError):
+        _parse_int("nan")

--- a/tests/unit/test_supply_import.py
+++ b/tests/unit/test_supply_import.py
@@ -294,10 +294,17 @@ def test_parse_bool_and_int_stay_loud_for_junk_tokens():
     """Junk tokens are blank ONLY for free-text columns; in boolean or
     numeric columns they must still raise a loud import problem, not
     silently coerce to the default/NULL."""
-    from app.routes.admin.supply_import_utils import _clean_str, _parse_bool, _parse_int
+    from app.routes.admin.supply_import_utils import (
+        _clean_str,
+        _parse_bool,
+        _parse_cents,
+        _parse_int,
+    )
 
     assert _clean_str("None") == "None"  # no junk handling here
     with pytest.raises(ValueError):
         _parse_bool("none", default=False)
     with pytest.raises(ValueError):
         _parse_int("nan")
+    with pytest.raises(ValueError):
+        _parse_cents("nan")

--- a/tests/unit/test_supply_models.py
+++ b/tests/unit/test_supply_models.py
@@ -104,12 +104,10 @@ def supply_seed(app):
 
 def test_supply_order_detail_round_trip_and_cascade(supply_seed):
     """SupplyOrderDetail attaches to WorkItem and cascades on delete."""
-    from datetime import date
-
     detail = SupplyOrderDetail(
         work_item_id=supply_seed["work_item"].id,
-        needed_by_date=date(2027, 1, 10),
-        delivery_location="Warehouse dock B",
+        pickup_time="Tuesday Evening (after 6 PM)",
+        additional_notes=None,
         created_by_user_id="test:supply_user",
     )
     db.session.add(detail)
@@ -117,7 +115,7 @@ def test_supply_order_detail_round_trip_and_cascade(supply_seed):
 
     item = db.session.query(WorkItem).filter_by(id=supply_seed["work_item"].id).one()
     assert item.supply_order_detail is not None
-    assert item.supply_order_detail.delivery_location == "Warehouse dock B"
+    assert item.supply_order_detail.pickup_time == "Tuesday Evening (after 6 PM)"
 
     db.session.delete(item)
     db.session.commit()
@@ -125,8 +123,8 @@ def test_supply_order_detail_round_trip_and_cascade(supply_seed):
     assert db.session.query(SupplyOrderDetail).count() == 0
 
 
-def test_line_detail_has_no_delivery_columns():
-    """SupplyOrderLineDetail does not have needed_by_date or delivery_location columns."""
+def test_line_detail_has_no_order_level_columns():
+    """Order-level pickup fields live on SupplyOrderDetail, not per line."""
     from app.models import SupplyOrderLineDetail
-    assert not hasattr(SupplyOrderLineDetail, "needed_by_date")
-    assert not hasattr(SupplyOrderLineDetail, "delivery_location")
+    assert not hasattr(SupplyOrderLineDetail, "pickup_time")
+    assert not hasattr(SupplyOrderLineDetail, "additional_notes")


### PR DESCRIPTION
## Summary

Implements the supply team's feedback on the Phase 1 ordering flow, plus one
bug found along the way:

1. **Pickup time replaces delivery details.** Departments pick orders up from   a staging location — they aren't delivered. The cart's "Delivery Details"   section (needed-by date + free-text location) is now "Pickup Details" with   a dropdown of five pickup slots and a note that the pickup location will   be communicated before the event. Choosing "Other…" requires the preferred
   date/time in Additional Notes at submit. The selected display string is   stored as a snapshot on SupplyOrderDetail.pickup_time`, so later wording   changes can't corrupt old orders. The options are hardcoded for now
   (rarely change; per-event config is a possible future step).
2. **Catalog shows what's already in the cart.** Each item row/card shows a   pill — `In order ×12`, or `In order: 2 lines · qty 13` when the item was   added multiple times — so requesters don't accidentally re-add. Built from   the already-eager-loaded cart lines (zero extra queries). Add behavior is   unchanged: duplicate adds still create separate lines, distinguished by
   notes.
3. **CSV import junk-string fix.** Blank spreadsheet cells were being stored   as literal "None"/"nan" strings and rendered as visible junk under the   catalog qty inputs. A new `_clean_text` treats junk tokens as blank for   the four free-text columns only; boolean/numeric columns still fail loudly   on junk (deliberate — silent coercion was considered and rejected). A   data-cleanup migration nulls existing junk rows.

## Downstream changes

- Line review, admin finalize, admin queue, all-orders, and portfolio landing  now display pickup time instead of needed-by date / delivery location.
- The admin finalize queue sorts oldest-submitted first. Warehouse urgency  sorting (by pickup slot) was deliberately deferred — warehouse tooling is  Phase 2.
