### PR TITLE
Show each line's review group on budget approval screens

### DIFF
--- a/app/routes/work/work_items/view.py
+++ b/app/routes/work/work_items/view.py
@@ -14,7 +14,11 @@ from app.models import (
     COMMENT_VISIBILITY_PUBLIC,
     AUDIT_EVENT_VIEW,
 )
-from app.line_details import get_line_amount_cents, get_line_detail
+from app.line_details import (
+    get_line_amount_cents,
+    get_line_detail,
+    get_line_routing_approval_group,
+)
 from app.routes import get_user_ctx
 from .. import work_bp
 from ..helpers import (
@@ -91,10 +95,11 @@ def work_item_detail(event: str, dept: str, public_id: str, work_type_slug: str 
         for line in lines
         if line.budget_detail and line.budget_detail.routed_approval_group_id
     }
-    group_names = {}
+    groups_by_id = {}
     if routed_ids:
         for ag in ApprovalGroup.query.filter(ApprovalGroup.id.in_(routed_ids)).all():
-            group_names[ag.id] = ag.name
+            groups_by_id[ag.id] = ag
+    group_names = {gid: ag.name for gid, ag in groups_by_id.items()}
 
     group_subtotals = compute_group_subtotals(lines, group_names)
     distinct_group_count = sum(1 for g in group_subtotals if g.group_id is not None)
@@ -137,6 +142,7 @@ def work_item_detail(event: str, dept: str, public_id: str, work_type_slug: str 
         total_lines_count=total_lines_count,
         lines_filtered=lines_filtered,
         group_subtotals=group_subtotals,
+        groups_by_id=groups_by_id,
         show_group_breakdown=show_group_breakdown,
         visible_requested_cents=visible_requested_cents,
         visible_approved_cents=visible_approved_cents,
@@ -293,6 +299,10 @@ def quick_review(event: str, dept: str, public_id: str, work_type_slug: str = "b
             "detail": detail,
             "review": review,
             "total_cents": total_cents,
+            # Routed approval group for the per-line "Review Group" pill.
+            # Polymorphic accessor, so this is safe for any worktype whose
+            # quick_review template chooses to render it.
+            "group": get_line_routing_approval_group(line),
         })
 
     # Pick the per-worktype template (same pattern as line_review).

--- a/app/templates/budget/_work_item_lines_table.html
+++ b/app/templates/budget/_work_item_lines_table.html
@@ -1,6 +1,7 @@
 {# templates/budget/_work_item_lines_table.html #}
 {# Partial: Budget lines table for work_item_detail.html #}
 {% from "macros/status_pill.html" import render_status_pill %}
+{% from "macros/group_pill.html" import render_group_pill %}
 
 <div style="display:flex; justify-content:space-between; align-items:center; gap:12px; margin-bottom:12px; flex-wrap:wrap;">
   <h3 style="margin:0;">Budget Lines</h3>
@@ -16,6 +17,7 @@
       <tr>
         <th style="width: 60px;">#</th>
         <th>Expense</th>
+        <th style="width: 110px;">Review Group</th>
         <th>Details</th>
         <th style="width: 80px;" class="right">Qty.</th>
         <th style="width: 100px;" class="right">Unit Cost</th>
@@ -23,7 +25,7 @@
         {% if show_approved_column %}
           <th style="width: 120px;" class="right">Approved</th>
         {% endif %}
-        <th style="width: 100px;">Status</th>
+        <th style="width: 120px;">Status</th>
         {% if status == "SUBMITTED" or status == "UNDER_REVIEW" or status == "NEEDS_INFO" %}
           <th style="width: 80px;"></th>
         {% endif %}
@@ -44,6 +46,9 @@
             {% else %}
               <span class="muted">-</span>
             {% endif %}
+          </td>
+          <td data-label="Review Group">
+            {{ render_group_pill(groups_by_id.get(detail.routed_approval_group_id) if detail and detail.routed_approval_group_id else None) }}
           </td>
           <td data-label="Details">
             {% if detail and detail.description %}
@@ -99,7 +104,7 @@
               {% if review_stage == "ADMIN_FINAL" %}
                 {{ render_status_pill(line_status, label="APPROVED") }}
               {% else %}
-                <span class="pill" style="background: #dbeafe; color: #1e40af;">RECOMMENDED</span>
+                <span class="pill" style="background: #dbeafe; color: #1e40af; white-space: nowrap;">RECOMMENDED</span>
               {% endif %}
             {% elif line_status == "REJECTED" %}
               {% if review_stage == "ADMIN_FINAL" %}
@@ -125,7 +130,7 @@
       {% if show_group_breakdown %}
         {% for g in group_subtotals %}
           <tr class="muted">
-            <td colspan="5" class="right">{{ g.group_name }} ({{ g.line_count }} line{% if g.line_count != 1 %}s{% endif %}):</td>
+            <td colspan="6" class="right">{{ g.group_name }} ({{ g.line_count }} line{% if g.line_count != 1 %}s{% endif %}):</td>
             <td class="right num">{{ format_currency(g.requested_cents) }}</td>
             {% if show_approved_column %}
               <td class="right num">{{ format_currency(g.approved_cents) }}</td>
@@ -138,7 +143,7 @@
         {% endfor %}
         {% if lines_filtered %}
           <tr style="font-weight: 700;">
-            <td colspan="5" class="right">Your total ({{ lines|length }} line{% if lines|length != 1 %}s{% endif %}):</td>
+            <td colspan="6" class="right">Your total ({{ lines|length }} line{% if lines|length != 1 %}s{% endif %}):</td>
             <td class="right num">{{ format_currency(visible_requested_cents) }}</td>
             {% if show_approved_column %}
               <td class="right num" style="color: #059669;">{{ format_currency(visible_approved_cents) }}</td>
@@ -151,7 +156,7 @@
         {% endif %}
       {% endif %}
       <tr style="font-weight: 700;">
-        <td colspan="5" class="right">
+        <td colspan="6" class="right">
           {% if lines_filtered %}
             Full request total: <span class="muted small" style="font-weight: 400;">(incl. lines for other groups)</span>
           {% else %}
@@ -169,7 +174,7 @@
       </tr>
       {% if show_approved_column and totals.approved != totals.requested %}
         <tr class="muted">
-          <td colspan="5" class="right">Difference:</td>
+          <td colspan="6" class="right">Difference:</td>
           <td></td>
           <td class="right num" style="{% if totals.approved < totals.requested %}color: #dc3545;{% else %}color: #059669;{% endif %}">
             {% set total_diff = totals.approved - totals.requested %}

--- a/app/templates/budget/quick_review.html
+++ b/app/templates/budget/quick_review.html
@@ -1,6 +1,7 @@
 {# templates/budget/quick_review.html #}
 {% extends "layout/base.html" %}
 {% from "macros/status_pill.html" import render_status_pill %}
+{% from "macros/group_pill.html" import render_group_pill %}
 
 {% block title %}Quick Review - {{ work_item.public_id }}{% endblock %}
 
@@ -95,6 +96,7 @@
         <tr>
           <th style="width: 50px;">#</th>
           <th style="width: 180px;">Expense Account</th>
+          <th style="width: 110px;">Review Group</th>
           <th>Description</th>
           <th style="width: 100px;" class="right">Amount</th>
           <th style="width: 100px;">Status</th>
@@ -116,6 +118,9 @@
             </td>
             <td>
               <div style="font-size: 13px;">{{ detail.expense_account.name if detail and detail.expense_account else '-' }}</div>
+            </td>
+            <td>
+              {{ render_group_pill(item.group) }}
             </td>
             <td>
               <div style="font-size: 13px; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="{{ detail.description if detail else '' }}">

--- a/app/templates/macros/group_pill.html
+++ b/app/templates/macros/group_pill.html
@@ -1,0 +1,41 @@
+{# templates/macros/group_pill.html #}
+{# Renders a small colored pill for an approval (review) group.
+
+   Used on the BUDGET line-listing screens (quick_review, work item detail) so
+   reviewers can tell which approval group each line routes to at a glance:
+   - Approvers in multiple groups can distinguish their groups' lines.
+   - Super admins (who see every line) can see each line's routed group.
+
+   Color is chosen deterministically from `group.id` so the same group is the
+   same color everywhere — lines can be clustered visually even in line order.
+   The `code` text label is always shown so color is never the only signal
+   (accessibility) and rare palette collisions stay unambiguous.
+
+   `group` is an ApprovalGroup or None. None (e.g. a line whose routing
+   snapshot has not been taken yet, pre-dispatch) renders a muted dash.
+
+   Usage:
+     {% from "macros/group_pill.html" import render_group_pill %}
+     {{ render_group_pill(line_group) }}
+#}
+
+{% macro render_group_pill(group, extra_style=None) -%}
+{%- if group -%}
+  {# bg/fg pairs — light pastel background, dark readable text. #}
+  {%- set palette = [
+      ("#dbeafe", "#1e40af"),
+      ("#dcfce7", "#166534"),
+      ("#fef3c7", "#92400e"),
+      ("#ffe4e6", "#9f1239"),
+      ("#ede9fe", "#5b21b6"),
+      ("#cffafe", "#155e75"),
+      ("#ffedd5", "#9a3412"),
+      ("#ecfccb", "#3f6212"),
+  ] -%}
+  {%- set colors = palette[group.id % (palette|length)] -%}
+  <span class="pill" title="{{ group.name }}"
+        style="background: {{ colors[0] }}; color: {{ colors[1] }};{% if extra_style %} {{ extra_style }}{% endif %}">{{ group.code }}</span>
+{%- else -%}
+  <span class="muted">&mdash;</span>
+{%- endif -%}
+{%- endmacro %}

--- a/tests/integration/test_review_group_column.py
+++ b/tests/integration/test_review_group_column.py
@@ -1,0 +1,158 @@
+"""Integration tests: per-line 'Review Group' column/pill on the BUDGET
+review screens (work item detail + quick review).
+
+Mirrors the seeding pattern in test_group_subtotals_view.py.
+"""
+from app import db
+from app.models import (
+    WorkItem, WorkLine, BudgetLineDetail, ApprovalGroup, UserRole,
+    REQUEST_KIND_PRIMARY, WORK_ITEM_STATUS_SUBMITTED,
+    WORK_LINE_STATUS_PENDING, REVIEW_STAGE_APPROVAL_GROUP, ROLE_APPROVER,
+)
+
+
+def _make_multi_group_item(data, routing):
+    """Create a SUBMITTED work item with one line per (group_id, price, qty)."""
+    work_item = WorkItem(
+        portfolio_id=data["portfolio"].id,
+        request_kind=REQUEST_KIND_PRIMARY,
+        status=WORK_ITEM_STATUS_SUBMITTED,
+        public_id="TST2026-TESTDEPT-BUD-1",
+        created_by_user_id=data["admin"].id,
+    )
+    db.session.add(work_item)
+    db.session.flush()
+
+    for idx, (group_id, price, qty) in enumerate(routing, start=1):
+        line = WorkLine(
+            work_item_id=work_item.id, line_number=idx,
+            status=WORK_LINE_STATUS_PENDING,
+            current_review_stage=REVIEW_STAGE_APPROVAL_GROUP,
+        )
+        db.session.add(line)
+        db.session.flush()
+        db.session.add(BudgetLineDetail(
+            work_line_id=line.id,
+            expense_account_id=data["expense_account"].id,
+            spend_type_id=data["spend_type"].id,
+            quantity=qty, unit_price_cents=price,
+            routed_approval_group_id=group_id,
+        ))
+    db.session.commit()
+    return work_item
+
+
+def _second_group(data):
+    ag = ApprovalGroup(
+        work_type_id=data["work_type"].id,
+        code="HOTEL", name="Hotel Team", is_active=True,
+    )
+    db.session.add(ag)
+    db.session.commit()
+    return ag
+
+
+def test_detail_table_shows_review_group_pills(app, client, seed_workflow_data):
+    data = seed_workflow_data
+    tech = data["approval_group"]           # code TECH / "Tech Team"
+    hotel = _second_group(data)
+    _make_multi_group_item(data, [
+        (tech.id, 200_00, 2),
+        (hotel.id, 50_00, 3),
+    ])
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:admin"   # SUPER_ADMIN sees all lines
+
+    resp = client.get("/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Review Group" in html               # new column header
+    # Pills carry the group code as text and the full name as a title tooltip.
+    assert 'title="Tech Team"' in html
+    assert 'title="Hotel Team"' in html
+    assert ">TECH<" in html
+    assert ">HOTEL<" in html
+
+
+def test_quick_review_shows_review_group_pills(app, client, seed_workflow_data):
+    data = seed_workflow_data
+    tech = data["approval_group"]
+    hotel = _second_group(data)
+    _make_multi_group_item(data, [
+        (tech.id, 200_00, 2),
+        (hotel.id, 50_00, 3),
+    ])
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:admin"
+
+    resp = client.get(
+        "/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1/quick-review"
+    )
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Review Group" in html
+    assert 'title="Tech Team"' in html          # pill (no subtotal footer here)
+    assert 'title="Hotel Team"' in html
+
+
+def test_multi_group_reviewer_sees_both_group_pills_on_quick_review(
+    app, client, seed_workflow_data
+):
+    """The core complaint: a reviewer in two groups can now tell their lines
+    apart by group."""
+    data = seed_workflow_data
+    tech = data["approval_group"]
+    hotel = _second_group(data)
+    # Third group the reviewer does NOT belong to (its line stays hidden).
+    av = ApprovalGroup(
+        work_type_id=data["work_type"].id,
+        code="AV", name="AV Team", is_active=True,
+    )
+    db.session.add(av)
+    db.session.commit()
+
+    _make_multi_group_item(data, [
+        (tech.id, 200_00, 2),    # visible
+        (hotel.id, 100_00, 3),   # visible
+        (av.id, 50_00, 1),       # hidden from this reviewer
+    ])
+    for gid in (tech.id, hotel.id):
+        db.session.add(UserRole(
+            user_id=data["reviewer"].id, role_code=ROLE_APPROVER,
+            approval_group_id=gid,
+        ))
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:reviewer"
+
+    resp = client.get(
+        "/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1/quick-review"
+    )
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert 'title="Tech Team"' in html
+    assert 'title="Hotel Team"' in html
+    assert 'title="AV Team"' not in html        # hidden group's line not shown
+
+
+def test_predispatch_line_shows_muted_dash(app, client, seed_workflow_data):
+    """A line with no routing snapshot yet renders a muted dash, not a pill."""
+    data = seed_workflow_data
+    _make_multi_group_item(data, [
+        (None, 200_00, 2),
+    ])
+
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:admin"
+
+    resp = client.get("/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Review Group" in html               # column still present


### PR DESCRIPTION
## Problem
  
  Reviewers doing first-round approvals couldn't tell which approval group a budget line belonged to:
  
  - An approver in **multiple** approval groups saw lines routed to all of their   groups intermixed, with nothing labeling which was which.
  - **Super admins** bypass the line filter entirely and see *every* line, with  no indication of each line's routed group.
  
  ## Change
  
 Add an always-on **"Review Group"** column — a small colored pill — to the two BUDGET line-listing screens (work item detail and Quick Review). Line order is preserved (no reordering), and the color is derived deterministically from the
  group id so the same group is the same color everywhere, letting you cluster lines visually at a glance. The pill always shows the group `code` as text, so color is never the only signal.
  
The data already existed — `BudgetLineDetail.routed_approval_group_id` is a snapshot taken at dispatch — so this is a pure display change: **no model or schema migration.**
