### PR TITLE
Chassis mechanical fixes: scanner-block NameError, worktype-scoped force check-in, redirect-guard   bypasses

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -352,7 +352,7 @@ def create_app() -> Flask:
         _ip_404_counts[ip] = [t for t in hits if t > cutoff]
         if len(_ip_404_counts[ip]) >= _BLOCK_THRESHOLD:
             _ip_blocked_until[ip] = now + _BLOCK_DURATION
-            current_app.logger.warning(
+            app.logger.warning(
                 f"Blocked IP {ip} for {_BLOCK_DURATION}s after {_BLOCK_THRESHOLD} "
                 f"scanner hits in {_BLOCK_WINDOW}s"
             )
@@ -389,8 +389,9 @@ def create_app() -> Flask:
     # -----------------------------
     # Helpers (auth + scoping)
     # -----------------------------
-    # Demo / dev seeding helpers live in app/seeds/dev_seed.py and are
-    # imported directly by their callers (routes/dev.py, routes/home.py).
+    # Demo / dev seeding helpers live in app/seeds/demo_data.py and
+    # app/seeds/demo_users.py and are imported directly by their callers
+    # (routes/dev.py, app/cli.py).
 
     def ensure_bootstrap_admins():
         """Ensure essential admin accounts exist. Runs on every deployment."""

--- a/app/routes/admin/helpers.py
+++ b/app/routes/admin/helpers.py
@@ -232,9 +232,10 @@ def safe_redirect_url(url: str | None, fallback: str = "/") -> str:
 
     url = url.strip()
 
-    # Only allow paths that start with / (relative to our host)
-    # Reject protocol-relative URLs (//evil.com), absolute URLs, and schemes
-    if not url.startswith("/") or url.startswith("//"):
+    # Only allow paths that start with / (relative to our host).
+    # Reject protocol-relative URLs (//evil.com), absolute URLs, schemes,
+    # and the backslash variant (/\evil.com — browsers normalize \ to /).
+    if not url.startswith("/") or url[1:2] in ("/", "\\"):
         return fallback
 
     return url

--- a/app/routes/admin/helpers.py
+++ b/app/routes/admin/helpers.py
@@ -223,7 +223,8 @@ def safe_redirect_url(url: str | None, fallback: str = "/") -> str:
     Validate a user-supplied redirect URL to prevent open redirect attacks.
 
     Only allows relative paths on the same host. Rejects external URLs,
-    javascript: URIs, data: URIs, and protocol-relative URLs.
+    javascript: URIs, data: URIs, protocol-relative URLs (including the
+    backslash and embedded tab/CR/LF variants browsers normalize away).
 
     Returns the URL if safe, otherwise returns the fallback.
     """
@@ -231,6 +232,11 @@ def safe_redirect_url(url: str | None, fallback: str = "/") -> str:
         return fallback
 
     url = url.strip()
+
+    # Reject embedded tab/CR/LF: browsers strip these during URL parsing
+    # (WHATWG), so "/\t/evil.com" would be read as protocol-relative.
+    if any(ch in url for ch in "\t\r\n"):
+        return fallback
 
     # Only allow paths that start with / (relative to our host).
     # Reject protocol-relative URLs (//evil.com), absolute URLs, schemes,

--- a/app/routes/approvals/reviews.py
+++ b/app/routes/approvals/reviews.py
@@ -42,8 +42,6 @@ from . import approvals_bp
 from .helpers import (
     is_reviewer_for_line,
     can_respond_to_work_item,
-    require_reviewer_for_line,
-    require_checkout_for_review,
     get_review_for_line,
     get_or_create_review,
     apply_review_decision,

--- a/app/routes/work/helpers/checkout.py
+++ b/app/routes/work/helpers/checkout.py
@@ -24,6 +24,7 @@ from .context import (
     PortfolioContext,
     WorkItemPerms,
     build_portfolio_perms,
+    is_worktype_admin,
 )
 
 
@@ -161,9 +162,14 @@ def checkin_work_item(work_item: WorkItem, user_ctx: UserContext, force: bool = 
     if not locked_item.checked_out_by_user_id:
         return False  # Nothing to release
 
-    # Check permission
+    # Check permission: the current holder may always release; admins may
+    # force-release. "Admin" is worktype-scoped — SUPER_ADMIN anywhere, or
+    # WORKTYPE_ADMIN for THIS item's work type (a TechOps admin can force-
+    # release TechOps items but not Budget items).
     is_current_holder = locked_item.checked_out_by_user_id == user_ctx.user_id
-    is_admin = user_ctx.is_super_admin
+    is_admin = user_ctx.is_super_admin or is_worktype_admin(
+        user_ctx, locked_item.portfolio.work_type_id
+    )
 
     if not is_current_holder and not (is_admin and force):
         return False

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -710,12 +710,12 @@ def send_submission_reminders(
                 ok = False
 
             # send_email() adds the NotificationLog row but does not commit
-            # (per its docstring contract: "Caller handles commit"). HTTP
-            # routes get an implicit commit at request-end; CLI commands do
-            # not, so without this each NotificationLog row would be discarded
-            # on process exit. Commit per-recipient (not end-of-run) so a
-            # mid-run crash still leaves a clear audit trail of which sends
-            # already went out.
+            # (per its docstring contract: "Caller handles commit"). There is
+            # NO implicit commit anywhere — Flask-SQLAlchemy rolls back at
+            # request teardown. HTTP routes commit explicitly after notify_*
+            # calls; CLI commands must too. Commit per-recipient (not
+            # end-of-run) so a mid-run crash still leaves a clear audit trail
+            # of which sends already went out.
             try:
                 db.session.commit()
             except Exception:

--- a/tests/integration/test_checkin_force.py
+++ b/tests/integration/test_checkin_force.py
@@ -1,0 +1,64 @@
+"""Force check-in authority: worktype admin of the item's work type."""
+from datetime import datetime, timedelta
+
+from app import db
+from app.models import (
+    User, UserRole, WorkItem,
+    ROLE_WORKTYPE_ADMIN, ROLE_APPROVER,
+    WORK_ITEM_STATUS_SUBMITTED,
+)
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = user_id
+
+
+def _checkout_to(data, holder_id):
+    """Put the seeded item in SUBMITTED with an active checkout held by holder_id."""
+    item = data["work_item"]
+    item.status = WORK_ITEM_STATUS_SUBMITTED
+    item.checked_out_by_user_id = holder_id
+    item.checked_out_at = datetime.utcnow()
+    item.checked_out_expires_at = datetime.utcnow() + timedelta(minutes=30)
+    db.session.commit()
+    return item
+
+
+CHECKIN_URL = "/TST2026/TESTDEPT/budget/item/TST2026-TESTDEPT-BUD-1/checkin"
+
+
+def test_worktype_admin_can_force_release(client, seed_draft_work_item):
+    data = seed_draft_work_item
+    wt_admin = User(id="test:wtadmin", email="wtadmin@test.local",
+                    display_name="WT Admin", is_active=True)
+    db.session.add(wt_admin)
+    db.session.add(UserRole(user_id="test:wtadmin",
+                            role_code=ROLE_WORKTYPE_ADMIN,
+                            work_type_id=data["work_type"].id))
+    _checkout_to(data, data["reviewer"].id)
+
+    _login(client, "test:wtadmin")
+    resp = client.post(CHECKIN_URL, follow_redirects=False)
+    assert resp.status_code == 302
+
+    item = db.session.get(WorkItem, data["work_item"].id)
+    assert item.checked_out_by_user_id is None
+
+
+def test_non_holder_approver_cannot_force_release(client, seed_draft_work_item):
+    data = seed_draft_work_item
+    other = User(id="test:other", email="other@test.local",
+                 display_name="Other Approver", is_active=True)
+    db.session.add(other)
+    db.session.add(UserRole(user_id="test:other",
+                            role_code=ROLE_APPROVER,
+                            approval_group_id=data["approval_group"].id))
+    _checkout_to(data, data["reviewer"].id)
+
+    _login(client, "test:other")
+    resp = client.post(CHECKIN_URL, follow_redirects=False)
+    assert resp.status_code == 302
+
+    item = db.session.get(WorkItem, data["work_item"].id)
+    assert item.checked_out_by_user_id == data["reviewer"].id

--- a/tests/unit/test_safe_redirect_url.py
+++ b/tests/unit/test_safe_redirect_url.py
@@ -1,0 +1,13 @@
+"""Open-redirect guard for user-supplied return URLs."""
+from app.routes.admin.helpers import safe_redirect_url
+
+
+def test_rejects_backslash_protocol_relative():
+    # Browsers normalize "/\" to "//" — must be treated as external.
+    assert safe_redirect_url("/\\evil.com", fallback="/safe") == "/safe"
+    assert safe_redirect_url("//evil.com", fallback="/safe") == "/safe"
+
+
+def test_allows_normal_relative_paths():
+    assert safe_redirect_url("/admin/budget/", fallback="/safe") == "/admin/budget/"
+    assert safe_redirect_url("https://evil.com", fallback="/safe") == "/safe"

--- a/tests/unit/test_safe_redirect_url.py
+++ b/tests/unit/test_safe_redirect_url.py
@@ -6,8 +6,11 @@ def test_rejects_backslash_protocol_relative():
     # Browsers normalize "/\" to "//" — must be treated as external.
     assert safe_redirect_url("/\\evil.com", fallback="/safe") == "/safe"
     assert safe_redirect_url("//evil.com", fallback="/safe") == "/safe"
+    # Embedded tab is stripped by browsers during URL parsing (WHATWG),
+    # so "/\t/evil.com" would otherwise be read as protocol-relative.
+    assert safe_redirect_url("/\t/evil.com", fallback="/safe") == "/safe"
+    assert safe_redirect_url("https://evil.com", fallback="/safe") == "/safe"
 
 
 def test_allows_normal_relative_paths():
     assert safe_redirect_url("/admin/budget/", fallback="/safe") == "/admin/budget/"
-    assert safe_redirect_url("https://evil.com", fallback="/safe") == "/safe"

--- a/tests/unit/test_scanner_blocking.py
+++ b/tests/unit/test_scanner_blocking.py
@@ -1,0 +1,14 @@
+"""Scanner/bot flood protection — threshold blocking must not error."""
+
+
+def test_scanner_threshold_blocks_ip_without_error(client):
+    # 10 scanner-path 404s in the window trip the block threshold.
+    # The 10th request executes the block+log branch in _record_ip_404;
+    # before the fix that branch raises NameError (current_app undefined).
+    for _ in range(10):
+        resp = client.get("/wp-admin")
+        assert resp.status_code in (403, 404)
+
+    # Once blocked, subsequent requests get a clean 403.
+    resp = client.get("/wp-admin")
+    assert resp.status_code == 403

--- a/tests/unit/test_scanner_blocking.py
+++ b/tests/unit/test_scanner_blocking.py
@@ -2,9 +2,13 @@
 
 
 def test_scanner_threshold_blocks_ip_without_error(client):
-    # 10 scanner-path 404s in the window trip the block threshold.
-    # The 10th request executes the block+log branch in _record_ip_404;
-    # before the fix that branch raises NameError (current_app undefined).
+    # Each scanner request is counted twice — once in the block_scanners
+    # before_request hook and again in the track_404_ips after_request hook
+    # (which Flask still runs on before_request-short-circuited responses) —
+    # so the effective block threshold is crossed around the 5th request,
+    # well within this loop of 10. The request that crosses it executes the
+    # block+log branch in _record_ip_404; before the fix that branch raises
+    # NameError (current_app undefined).
     for _ in range(10):
         resp = client.get("/wp-admin")
         assert resp.status_code in (403, 404)


### PR DESCRIPTION
Four fixes from a full-codebase health review. No schema changes; no behavior changes beyond the
  named bugs.
     
## 1. Scanner-block threshold no longer 500s (`app/__init__.py`)
 `_record_ip_404` referenced `current_app`, which is never imported in this file — a latent   `NameError` that fired the moment an IP tripped the 10-404s block threshold (the IP still got  blocked, but the triggering request errored). Now uses the `app` closure variable. Also corrected a  stale comment pointing at the long-renamed `app/seeds/dev_seed.py`.
     
## 2. Worktype admins can actually force check-in (`app/routes/work/helpers/checkout.py`)  
The perms layer shows the "end review session" button to worktype admins, but `checkin_work_item`   only honored force-release for `SUPER_ADMIN` — so a non-super BUDGET admin's click silently failed,   with no other release path short of the 30-minute lock expiry. Force authority is now   worktype-scoped: `SUPER_ADMIN` anywhere, or `WORKTYPE_ADMIN` of the item's own work type (a TechOps   admin can force-release TechOps items, not Budget items). Helper signature unchanged; no caller changes.

## 3. Open-redirect guard rejects the backslash and tab variants (`app/routes/admin/helpers.py`)  
 `safe_redirect_url` rejected `//evil.com` but accepted `/\evil.com` and `/%09/evil.com` (embedded   tab). Browsers strip `\`→`/` and ASCII tab/CR/LF during URL parsing (WHATWG), making both  protocol-relative → off-site redirect. Now rejects all three.

## 4. Hygiene
Removed two imported-but-never-called names in `app/routes/approvals/reviews.py` (enforcement lives   inside `apply_review_decision`); corrected a comment in `app/services/notifications.py` that falsely   claimed Flask commits at request end.
