### PR TITLE
Fix/budget scoping

### DIFF
--- a/app/routes/admin_final/dashboard.py
+++ b/app/routes/admin_final/dashboard.py
@@ -17,11 +17,6 @@ from app.models import (
     WORK_ITEM_STATUS_AWAITING_DISPATCH,
     WORK_ITEM_STATUS_SUBMITTED,
     WORK_ITEM_STATUS_FINALIZED,
-    WORK_LINE_STATUS_PENDING,
-    WORK_LINE_STATUS_NEEDS_INFO,
-    WORK_LINE_STATUS_NEEDS_ADJUSTMENT,
-    WORK_LINE_STATUS_APPROVED,
-    WORK_LINE_STATUS_REJECTED,
 )
 from app.routes import get_user_ctx
 from app.routes.work.helpers import format_currency, friendly_status, get_budget_work_type
@@ -35,6 +30,8 @@ from .helpers import (
     get_finalization_summary,
     finalize_work_item,
     unfinalize_work_item,
+    get_budget_admin_stats,
+    get_budget_approval_groups,
 )
 
 
@@ -249,50 +246,36 @@ def budget_admin_home():
     Budget admin landing page - accessible by Budget Worktype Admins + Super Admins.
     """
     from app.routes.work.helpers import get_enabled_department_ids_for_event
+    from app.routes.home import get_selected_event_cycle
+    from app.models import WorkType
 
     user_ctx = get_user_ctx()
     require_budget_admin(user_ctx)
 
-    # Gather summary statistics
-    stats = {
-        "submitted_items": WorkItem.query.filter_by(
-            status=WORK_ITEM_STATUS_SUBMITTED,
-            is_archived=False
-        ).count(),
-        "finalized_items": WorkItem.query.filter_by(
-            status=WORK_ITEM_STATUS_FINALIZED,
-            is_archived=False
-        ).count(),
-        "pending_lines": WorkLine.query.filter_by(
-            status=WORK_LINE_STATUS_PENDING
-        ).count(),
-        "kicked_back_lines": WorkLine.query.filter(
-            WorkLine.status.in_([WORK_LINE_STATUS_NEEDS_INFO, WORK_LINE_STATUS_NEEDS_ADJUSTMENT])
-        ).count(),
-        "approved_lines": WorkLine.query.filter_by(
-            status=WORK_LINE_STATUS_APPROVED
-        ).count(),
-        "rejected_lines": WorkLine.query.filter_by(
-            status=WORK_LINE_STATUS_REJECTED
-        ).count(),
-    }
+    budget_wt = WorkType.query.filter_by(code="BUDGET").first()
+    selected_cycle, show_all_events = get_selected_event_cycle()
 
-    # Get approval groups for quick links
-    approval_groups = ApprovalGroup.query.filter_by(is_active=True).order_by(
-        ApprovalGroup.sort_order.asc(),
-        ApprovalGroup.name.asc()
-    ).all()
+    # Stat tiles: BUDGET-only, scoped to the nav's selected event
+    # ("All events" keeps the cross-event totals).
+    stats = get_budget_admin_stats(selected_cycle, show_all_events)
+
+    # Get BUDGET approval groups for quick links (other worktypes' groups
+    # belong on their own admin pages).
+    approval_groups = get_budget_approval_groups()
 
     # Get filter options for department navigation
     event_cycles = get_active_event_cycles()
     departments = get_active_departments()
 
-    # Department progress for default event
-    default_event = EventCycle.query.filter_by(is_default=True, is_active=True).first()
-    if not default_event:
-        default_event = EventCycle.query.filter_by(is_active=True).order_by(
-            EventCycle.sort_order
-        ).first()
+    # Department progress panel follows the selected event; falls back to
+    # the default cycle when "All events" is selected.
+    default_event = selected_cycle
+    if default_event is None:
+        default_event = EventCycle.query.filter_by(is_default=True, is_active=True).first()
+        if not default_event:
+            default_event = EventCycle.query.filter_by(is_active=True).order_by(
+                EventCycle.sort_order
+            ).first()
 
     event_progress = None
     if default_event:
@@ -303,6 +286,7 @@ def budget_admin_home():
             db.session.query(db.func.count(db.distinct(WorkPortfolio.department_id)))
             .join(WorkItem, WorkItem.portfolio_id == WorkPortfolio.id)
             .filter(WorkPortfolio.event_cycle_id == default_event.id)
+            .filter(WorkPortfolio.work_type_id == (budget_wt.id if budget_wt else -1))
             .filter(WorkPortfolio.is_archived.is_(False))
             .filter(WorkItem.is_archived.is_(False))
             .filter(WorkPortfolio.department_id.in_(enabled_dept_ids))
@@ -313,6 +297,7 @@ def budget_admin_home():
             db.session.query(WorkItem.status, db.func.count(WorkItem.id))
             .join(WorkPortfolio, WorkItem.portfolio_id == WorkPortfolio.id)
             .filter(WorkPortfolio.event_cycle_id == default_event.id)
+            .filter(WorkPortfolio.work_type_id == (budget_wt.id if budget_wt else -1))
             .filter(WorkPortfolio.is_archived.is_(False))
             .filter(WorkItem.is_archived.is_(False))
             .filter(WorkPortfolio.department_id.in_(enabled_dept_ids))

--- a/app/routes/admin_final/dashboard.py
+++ b/app/routes/admin_final/dashboard.py
@@ -324,6 +324,8 @@ def budget_admin_home():
         friendly_status=friendly_status,
         default_event=default_event,
         event_progress=event_progress,
+        selected_cycle=selected_cycle,
+        show_all_events=show_all_events,
     )
 
 

--- a/app/routes/admin_final/helpers.py
+++ b/app/routes/admin_final/helpers.py
@@ -1100,3 +1100,55 @@ def get_budget_approval_groups() -> List[ApprovalGroup]:
         .order_by(ApprovalGroup.sort_order.asc(), ApprovalGroup.code.asc())
         .all()
     )
+
+
+def get_budget_admin_stats(selected_cycle, show_all_events: bool) -> dict:
+    """
+    Stat-tile counts for the budget admin home, scoped to the BUDGET work
+    type and (unless show_all_events) the selected event cycle.
+
+    Both scoping axes matter: multiple work types share the WorkItem/WorkLine
+    tables, and multiple event cycles run concurrently (~7 events/year).
+    """
+    from app.models import WorkType
+
+    budget_wt = WorkType.query.filter_by(code="BUDGET").first()
+
+    def _items():
+        q = (
+            WorkItem.query
+            .join(WorkPortfolio, WorkItem.portfolio_id == WorkPortfolio.id)
+            .filter(WorkPortfolio.work_type_id == (budget_wt.id if budget_wt else -1))
+            .filter(WorkItem.is_archived == False)  # noqa: E712
+        )
+        if not show_all_events and selected_cycle:
+            q = q.filter(WorkPortfolio.event_cycle_id == selected_cycle.id)
+        return q
+
+    def _lines():
+        q = (
+            WorkLine.query
+            .join(WorkItem, WorkLine.work_item_id == WorkItem.id)
+            .join(WorkPortfolio, WorkItem.portfolio_id == WorkPortfolio.id)
+            .filter(WorkPortfolio.work_type_id == (budget_wt.id if budget_wt else -1))
+            .filter(WorkItem.is_archived == False)  # noqa: E712
+        )
+        if not show_all_events and selected_cycle:
+            q = q.filter(WorkPortfolio.event_cycle_id == selected_cycle.id)
+        return q
+
+    return {
+        "submitted_items": _items().filter(
+            WorkItem.status == WORK_ITEM_STATUS_SUBMITTED).count(),
+        "finalized_items": _items().filter(
+            WorkItem.status == WORK_ITEM_STATUS_FINALIZED).count(),
+        "pending_lines": _lines().filter(
+            WorkLine.status == WORK_LINE_STATUS_PENDING).count(),
+        "kicked_back_lines": _lines().filter(
+            WorkLine.status.in_([WORK_LINE_STATUS_NEEDS_INFO,
+                                 WORK_LINE_STATUS_NEEDS_ADJUSTMENT])).count(),
+        "approved_lines": _lines().filter(
+            WorkLine.status == WORK_LINE_STATUS_APPROVED).count(),
+        "rejected_lines": _lines().filter(
+            WorkLine.status == WORK_LINE_STATUS_REJECTED).count(),
+    }

--- a/app/routes/admin_final/missing_budgets_report.py
+++ b/app/routes/admin_final/missing_budgets_report.py
@@ -15,6 +15,7 @@ from app.models import (
     Department,
     Division,
     EventCycle,
+    WorkType,
 )
 from app.routes.work.helpers import get_enabled_department_ids_for_event
 from app.routes import get_user_ctx
@@ -47,11 +48,15 @@ def get_departments_without_budgets(event_cycle_id: int) -> List[MissingBudgetRo
     # Get enabled department IDs for this event
     enabled_dept_ids = get_enabled_department_ids_for_event(event_cycle_id)
 
-    # Subquery: departments that DO have a budget request
+    budget_wt = WorkType.query.filter_by(code="BUDGET").first()
+
+    # Subquery: departments that DO have a BUDGET request (other work types
+    # — TechOps, Supply — must not count as "has a budget").
     departments_with_budgets = (
         db.session.query(WorkPortfolio.department_id)
         .join(WorkItem, WorkItem.portfolio_id == WorkPortfolio.id)
         .filter(WorkPortfolio.event_cycle_id == event_cycle_id)
+        .filter(WorkPortfolio.work_type_id == (budget_wt.id if budget_wt else -1))
         .filter(WorkItem.is_archived == False)
         .filter(WorkPortfolio.is_archived == False)
         .distinct()

--- a/app/routes/home.py
+++ b/app/routes/home.py
@@ -25,7 +25,6 @@ from app.models import (
     WorkTypeConfig,
     REVIEW_STAGE_APPROVAL_GROUP,
     REVIEW_STATUS_PENDING,
-    WORK_ITEM_STATUS_AWAITING_DISPATCH,
 )
 from app.routes.work.helpers import (
     get_active_work_types,
@@ -344,53 +343,6 @@ def index():
         if wt.id in user_accessible_work_types or is_super_admin
     ]
     context["work_types_with_access"] = work_types_with_access
-
-    # Get stats for budget admins (super admin or worktype admin for budget)
-    if is_budget_admin_user:
-        # Count work items at or past submitted (in the review workflow)
-        in_review_statuses = [
-            "SUBMITTED",
-            "UNDER_REVIEW",
-            "NEEDS_INFO",
-            "FINALIZED",
-        ]
-        in_review_count = (
-            db.session.query(WorkItem)
-            .filter(WorkItem.status.in_(in_review_statuses))
-            .filter(WorkItem.is_archived == False)
-            .count()
-        )
-        context["submitted_count"] = in_review_count
-
-        # Count items awaiting dispatch
-        dispatch_queue_count = (
-            db.session.query(WorkItem)
-            .filter(WorkItem.status == WORK_ITEM_STATUS_AWAITING_DISPATCH)
-            .filter(WorkItem.is_archived == False)
-            .count()
-        )
-        context["dispatch_queue_count"] = dispatch_queue_count
-
-        # Count requests needing reviewer group work (distinct WorkItems with pending lines)
-        from sqlalchemy import func
-        requests_needing_review = (
-            db.session.query(func.count(func.distinct(WorkItem.id)))
-            .join(WorkLine, WorkLine.work_item_id == WorkItem.id)
-            .filter(WorkItem.status == "SUBMITTED")
-            .filter(WorkItem.is_archived == False)
-            .filter(WorkLine.status == "PENDING")
-            .scalar()
-        ) or 0
-        context["requests_needing_review"] = requests_needing_review
-
-        # Count finalized requests
-        finalized_count = (
-            db.session.query(WorkItem)
-            .filter(WorkItem.status == "FINALIZED")
-            .filter(WorkItem.is_archived == False)
-            .count()
-        )
-        context["finalized_count"] = finalized_count
 
     # Get stats for approvers
     if approval_groups:

--- a/app/routes/home.py
+++ b/app/routes/home.py
@@ -278,13 +278,16 @@ def index():
             x["department"].name,
         ))
 
-        # Filter out departments not enabled for this event (super admins bypass this)
-        if not is_super_admin:
-            enabled_dept_ids = get_enabled_department_ids_for_event(default_cycle.id)
-            accessible_depts = [
-                d for d in accessible_depts
-                if d["department"].id in enabled_dept_ids
-            ]
+        # Filter out departments not enabled for this event — for everyone,
+        # super admins included. This list is personal navigation; enablement
+        # is managed from the event organization dashboard. Matches
+        # division_home (division.py), which has always filtered
+        # unconditionally.
+        enabled_dept_ids = get_enabled_department_ids_for_event(default_cycle.id)
+        accessible_depts = [
+            d for d in accessible_depts
+            if d["department"].id in enabled_dept_ids
+        ]
 
         # Batch-load all portfolios for this event cycle with work items and lines
         # This replaces N×M individual queries with 1 eager-loaded query

--- a/app/templates/admin_final/budget_home.html
+++ b/app/templates/admin_final/budget_home.html
@@ -98,7 +98,15 @@
   </section>
   {% endif %}
 
-  {# Stats Overview (all events) #}
+  {# Stats Overview — scoped to the selected event (or all events) #}
+  <div class="muted small" style="margin-bottom: 8px;">
+    Showing:
+    {% if show_all_events %}
+      all events
+    {% else %}
+      {{ selected_cycle.name if selected_cycle else 'no event selected' }}
+    {% endif %}
+  </div>
   <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-bottom: 24px;">
     <div class="card" style="text-align: center;">
       <div style="font-size: 32px; font-weight: 700; color: #0a66c2;">{{ stats.submitted_items }}</div>

--- a/tests/integration/test_home_disabled_departments.py
+++ b/tests/integration/test_home_disabled_departments.py
@@ -1,0 +1,41 @@
+"""Homepage must hide event-disabled departments — for super admins too."""
+from app import db
+from app.models import Department, DivisionMembership, EventCycleDepartment
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = user_id
+
+
+def test_super_admin_homepage_hides_disabled_departments(client, seed_workflow_data):
+    data = seed_workflow_data
+
+    # Put the seeded dept + a second dept into the seeded division, give the
+    # super admin a division membership so both appear via division access.
+    data["department"].division_id = data["division"].id
+    dept2 = Department(code="DEPT2", name="Second Department",
+                       is_active=True, division_id=data["division"].id)
+    db.session.add(dept2)
+    db.session.add(DivisionMembership(
+        user_id="test:admin",
+        division_id=data["division"].id,
+        event_cycle_id=data["cycle"].id,
+    ))
+    db.session.flush()
+
+    # Disable dept2 for this event.
+    db.session.add(EventCycleDepartment(
+        event_cycle_id=data["cycle"].id,
+        department_id=dept2.id,
+        is_enabled=False,
+    ))
+    db.session.commit()
+
+    _login(client, "test:admin")
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Test Department" in html          # enabled: shown
+    assert "Second Department" not in html    # event-disabled: hidden

--- a/tests/unit/test_budget_admin_stats.py
+++ b/tests/unit/test_budget_admin_stats.py
@@ -1,0 +1,70 @@
+"""Budget admin stats must count only BUDGET items in the selected event."""
+from app import db
+from app.models import (
+    WorkType, WorkPortfolio, WorkItem, EventCycle,
+    REQUEST_KIND_PRIMARY, WORK_ITEM_STATUS_SUBMITTED,
+)
+from app.routes.admin_final.helpers import get_budget_admin_stats
+
+
+def _add_item(work_type_id, cycle_id, dept_id, admin_id, public_id):
+    # seed_workflow_data already creates a WorkPortfolio for
+    # (BUDGET work type, cycle, dept); WorkPortfolio has a unique
+    # constraint on (work_type_id, event_cycle_id, department_id), so reuse
+    # a matching portfolio instead of inserting a duplicate.
+    p = WorkPortfolio.query.filter_by(
+        work_type_id=work_type_id, event_cycle_id=cycle_id, department_id=dept_id
+    ).first()
+    if p is None:
+        p = WorkPortfolio(work_type_id=work_type_id, event_cycle_id=cycle_id,
+                          department_id=dept_id, created_by_user_id=admin_id)
+        db.session.add(p)
+        db.session.flush()
+    db.session.add(WorkItem(
+        portfolio_id=p.id, request_kind=REQUEST_KIND_PRIMARY,
+        status=WORK_ITEM_STATUS_SUBMITTED, public_id=public_id,
+        created_by_user_id=admin_id,
+    ))
+
+
+def test_stats_exclude_other_worktypes(app, seed_workflow_data):
+    data = seed_workflow_data
+    techops_wt = WorkType(code="TECHOPS", name="TechOps", is_active=True)
+    db.session.add(techops_wt)
+    db.session.flush()
+
+    _add_item(data["work_type"].id, data["cycle"].id, data["department"].id,
+              data["admin"].id, "TST2026-TESTDEPT-BUD-9")
+    _add_item(techops_wt.id, data["cycle"].id, data["department"].id,
+              data["admin"].id, "TST2026-TESTDEPT-TEC-1")
+    db.session.commit()
+
+    stats = get_budget_admin_stats(data["cycle"], show_all_events=False)
+    assert stats["submitted_items"] == 1  # the TECHOPS item must not count
+
+
+def test_stats_scope_to_selected_event(app, seed_workflow_data):
+    data = seed_workflow_data
+    cycle2 = EventCycle(code="TST2027", name="Test Event 2027",
+                        is_active=True, is_default=False, sort_order=2)
+    db.session.add(cycle2)
+    db.session.flush()
+
+    _add_item(data["work_type"].id, data["cycle"].id, data["department"].id,
+              data["admin"].id, "TST2026-TESTDEPT-BUD-9")
+    _add_item(data["work_type"].id, cycle2.id, data["department"].id,
+              data["admin"].id, "TST2027-TESTDEPT-BUD-1")
+    db.session.commit()
+
+    stats = get_budget_admin_stats(data["cycle"], show_all_events=False)
+    assert stats["submitted_items"] == 1
+
+    stats_all = get_budget_admin_stats(None, show_all_events=True)
+    assert stats_all["submitted_items"] == 2
+
+
+def test_budget_admin_home_renders(client, seed_workflow_data):
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:admin"
+    resp = client.get("/admin/budget/")
+    assert resp.status_code == 200

--- a/tests/unit/test_home_renders.py
+++ b/tests/unit/test_home_renders.py
@@ -1,0 +1,9 @@
+"""Home page renders for a budget admin after the dead stats block was removed."""
+
+
+def test_home_renders_for_budget_admin(client, seed_workflow_data):
+    with client.session_transaction() as sess:
+        sess["active_user_id"] = "test:admin"
+
+    resp = client.get("/")
+    assert resp.status_code == 200

--- a/tests/unit/test_missing_budgets_report.py
+++ b/tests/unit/test_missing_budgets_report.py
@@ -39,3 +39,23 @@ def test_dept_with_only_techops_item_is_still_missing_budget(app, seed_workflow_
     codes = {r.department_code for r in rows}
     # dept2 has a TECHOPS item but no BUDGET item — it IS missing a budget.
     assert "TECHDEPT" in codes
+
+
+def test_dept_with_budget_item_is_not_flagged_missing(app, seed_workflow_data):
+    data = seed_workflow_data
+    # seed_workflow_data already made an empty BUDGET portfolio for TESTDEPT;
+    # give it an actual BUDGET work item so it should NOT be "missing".
+    db.session.add(WorkItem(
+        portfolio_id=data["portfolio"].id,
+        request_kind=REQUEST_KIND_PRIMARY,
+        status=WORK_ITEM_STATUS_DRAFT,
+        public_id="TST2026-TESTDEPT-BUD-1",
+        created_by_user_id=data["admin"].id,
+    ))
+    db.session.commit()
+
+    rows = get_departments_without_budgets(data["cycle"].id)
+    codes = {r.department_code for r in rows}
+    # TESTDEPT now has a BUDGET item — must be excluded from the missing list.
+    # (Guards against a regression where the subquery matches nothing.)
+    assert "TESTDEPT" not in codes

--- a/tests/unit/test_missing_budgets_report.py
+++ b/tests/unit/test_missing_budgets_report.py
@@ -1,0 +1,41 @@
+"""Missing-budgets report must not count non-BUDGET work items as budgets."""
+from app import db
+from app.models import (
+    Department, WorkType, WorkPortfolio, WorkItem,
+    REQUEST_KIND_PRIMARY, WORK_ITEM_STATUS_DRAFT,
+)
+from app.routes.admin_final.missing_budgets_report import (
+    get_departments_without_budgets,
+)
+
+
+def test_dept_with_only_techops_item_is_still_missing_budget(app, seed_workflow_data):
+    data = seed_workflow_data
+
+    dept2 = Department(code="TECHDEPT", name="Tech Dept", is_active=True)
+    db.session.add(dept2)
+    techops_wt = WorkType(code="TECHOPS", name="TechOps", is_active=True)
+    db.session.add(techops_wt)
+    db.session.flush()
+
+    portfolio = WorkPortfolio(
+        work_type_id=techops_wt.id,
+        event_cycle_id=data["cycle"].id,
+        department_id=dept2.id,
+        created_by_user_id=data["admin"].id,
+    )
+    db.session.add(portfolio)
+    db.session.flush()
+    db.session.add(WorkItem(
+        portfolio_id=portfolio.id,
+        request_kind=REQUEST_KIND_PRIMARY,
+        status=WORK_ITEM_STATUS_DRAFT,
+        public_id="TST2026-TECHDEPT-TEC-1",
+        created_by_user_id=data["admin"].id,
+    ))
+    db.session.commit()
+
+    rows = get_departments_without_budgets(data["cycle"].id)
+    codes = {r.department_code for r in rows}
+    # dept2 has a TECHOPS item but no BUDGET item — it IS missing a budget.
+    assert "TECHDEPT" in codes


### PR DESCRIPTION
Four fixes from the general code review, all in the same theme: budget-admin surfaces were  counting or listing data across every work type and every event cycle. With a bunch  events a year and 3  live work types (BUDGET, TECHOPS, SUPPLY) sharing the same tables, those views were wrong. No schema  changes.

- Missing-budgets report no longer counts other work types
- `/admin/budget/` stat tiles scoped to BUDGET + selected event (`admin_final/dashboard.py`,   `admin_final/helpers.py`)
- Removed dead budget-admin stat computation from the home page (`home.py`)
- Homepage stops showing event-disabled departments to super admins (`home.py`)