### PR TITLE
Fix/hotel report and action row

### DIFF
--- a/app/routes/admin_final/hotel_rooms_report.py
+++ b/app/routes/admin_final/hotel_rooms_report.py
@@ -18,6 +18,7 @@ from app import db
 from app.models import (
     BudgetLineDetail, WorkLine, WorkItem, WorkPortfolio,
     ExpenseAccount, Department, UI_GROUP_HOTEL_SERVICES,
+    WORK_LINE_STATUS_REJECTED,
 )
 from app.routes import get_user_ctx
 from app.routes.work.helpers import format_currency
@@ -187,13 +188,21 @@ def group_hotel_rows(rows: List[HotelRoomLineRow]) -> List[dict]:
     groups = []
     for key in ordered_keys:
         group_rows = by_key[key]
+        # Stable sort, so the SQL ordering survives within each half.
+        group_rows.sort(key=lambda r: r.line_status == WORK_LINE_STATUS_REJECTED)
+        live = [r for r in group_rows if r.line_status != WORK_LINE_STATUS_REJECTED]
+        rejected = [r for r in group_rows if r.line_status == WORK_LINE_STATUS_REJECTED]
         groups.append({
             "pay_type_key": key,
             "pay_type": group_rows[0].pay_type,
             "rows": group_rows,
-            "room_subtotal": sum(r.rooms for r in group_rows),
-            "room_nights_subtotal": sum(r.room_nights for r in group_rows),
-            "cents_subtotal": sum(r.total_cents for r in group_rows),
+            # Subtotals cover live rows only, so the breakout agrees with the
+            # summary. Rejected weight is reported separately below the table.
+            "room_subtotal": sum(r.rooms for r in live),
+            "room_nights_subtotal": sum(r.room_nights for r in live),
+            "cents_subtotal": sum(r.total_cents for r in live),
+            "rejected_count": len(rejected),
+            "rejected_cents": sum(r.total_cents for r in rejected),
         })
     return groups
 
@@ -202,12 +211,18 @@ def build_hotel_summary(rows: List[HotelRoomLineRow]) -> dict:
     """
     Cross-tab of room counts by room type (rows) x pay type (columns), with row
     totals (per room type), column totals (per pay type), a grand total, and a
-    dollar total per pay-type column.
+    dollar total per pay-type column. Rejected lines are excluded.
 
     Returned shape is template-friendly: `pay_labels` and the per-column lists
     (`col_rooms`, `col_cents`) are all aligned to the same pay-type order, and
     each `matrix_rows` entry's `cells` list is aligned to that same order.
     """
+    # Rejected rooms are excluded here but still render in the breakout. The
+    # summary is a planning number; a rejected room will not be booked.
+    # The filter lives in this function rather than at the call site so a
+    # future caller cannot forget it.
+    rows = [r for r in rows if r.line_status != WORK_LINE_STATUS_REJECTED]
+
     # Ordered pay types present: known order first, then any unexpected keys.
     present_pay = {r.pay_type_key for r in rows}
     pay_keys = [k for k in PAY_TYPE_ORDER if k in present_pay]
@@ -296,6 +311,8 @@ def hotel_rooms_report_export():
         abort(400, "Event cycle is required for export")
 
     rows = get_hotel_rooms_data(filters.event_cycle_id, filters.department_id)
+    # Match the on-screen order so the export can be diffed against the page.
+    rows.sort(key=lambda r: r.line_status == WORK_LINE_STATUS_REJECTED)
 
     headers = [
         "Pay Type", "Department", "Request", "Room Type",

--- a/app/templates/admin_final/hotel_rooms_report.html
+++ b/app/templates/admin_final/hotel_rooms_report.html
@@ -1,5 +1,6 @@
 {# templates/admin_final/hotel_rooms_report.html #}
 {% extends "layout/base.html" %}
+{% from "macros/status_pill.html" import render_status_pill %}
 {% from "admin_final/report_macros.html" import
     report_header, report_filters, report_context,
     empty_state_no_event, empty_state_no_data
@@ -98,7 +99,8 @@
             </thead>
             <tbody>
               {% for r in group.rows %}
-                <tr>
+                {% set is_rejected = r.line_status == "REJECTED" %}
+                <tr{% if is_rejected %} class="muted" style="opacity: 0.65;"{% endif %}>
                   <td>{{ r.department_name }}</td>
                   <td><strong>{{ r.work_item_public_id }}</strong></td>
                   <td>{{ r.room_type }}</td>
@@ -106,7 +108,7 @@
                   <td class="right num">{{ r.nights }}</td>
                   <td class="right num">{{ format_currency(r.unit_price_cents) }}</td>
                   <td class="right num">{{ format_currency(r.total_cents) }}</td>
-                  <td>{{ r.line_status }}</td>
+                  <td>{{ render_status_pill(r.line_status) }}</td>
                 </tr>
               {% endfor %}
             </tbody>
@@ -119,6 +121,15 @@
                 <td class="right num">{{ format_currency(group.cents_subtotal) }}</td>
                 <td></td>
               </tr>
+              {% if group.rejected_count %}
+                <tr class="muted" style="font-weight: normal;">
+                  <td colspan="8" class="small">
+                    {{ group.rejected_count }} rejected line{{ 's' if group.rejected_count != 1 }}
+                    ({{ format_currency(group.rejected_cents) }}) excluded from the
+                    subtotal and the summary above.
+                  </td>
+                </tr>
+              {% endif %}
             </tfoot>
           </table>
         </div>

--- a/app/templates/budget/work_item_detail.html
+++ b/app/templates/budget/work_item_detail.html
@@ -115,29 +115,10 @@
       </a>
     {% endif %}
 
-    {# Admin Dispatch button #}
-    {% if perms.is_worktype_admin and status == "SUBMITTED" %}
-      <span style="border-left: 1px solid #a7f3d0; height: 24px; margin: 0 4px;"></span>
-      <a class="btn" href="{{ url_for('dispatch.dashboard') }}" style="position: relative;">
-      Assign Reviewers</a>
-    {% endif %}
-
-    {# Dashboard link for reviewers (not shown for drafts) #}
-    {% if not perms.is_draft and (perms.is_worktype_admin or perms.is_checked_out_by_current_user) %}
-      <a class="btn" href="{{ url_for('approvals.dashboard_home') }}">
-        Review Queue
-      </a>
-    {% endif %}
-
-    {# Admin Final Review button #}
-    {% if perms.is_worktype_admin and status == "SUBMITTED" %}
-      <a class="btn" href="{{ url_for('admin_final.dashboard') }}">
-        Admin Final Queue
-      </a>
-    {% endif %}
-
     {# Extension Grant/Revoke button (admin only) #}
-    {% if perms.is_worktype_admin %}
+    {# Extensions move the submission deadline, so they are meaningless once the
+       request is in. The badge stays as the historical record. #}
+    {% if perms.is_worktype_admin and perms.is_draft %}
       {% if work_item.extension_granted %}
         <form method="post"
               action="{{ url_for('work.work_item_revoke_extension', event=ctx.event_cycle.code, dept=ctx.department.code, work_type_slug=ctx.work_type.config.url_slug, public_id=work_item.public_id) }}"

--- a/tests/integration/test_hotel_rooms_report_rejected.py
+++ b/tests/integration/test_hotel_rooms_report_rejected.py
@@ -1,0 +1,48 @@
+"""Rejected hotel lines stay visible in the breakout but leave the summary.
+
+The summary is a planning number. A rejected room is not a room anyone will
+book, so counting it overstates the event.
+"""
+from app.routes.admin_final.hotel_rooms_report import (
+    HotelRoomLineRow, build_hotel_summary, group_hotel_rows,
+)
+
+
+def _row(pay_key="MAGPAID", status="APPROVED", rooms=2, cents=20000, dept="Ops"):
+    return HotelRoomLineRow(
+        department_name=dept, work_item_id=1, work_item_public_id="TST-1",
+        line_number=1, account_code=f"HTL_STD_{pay_key}", room_type="Standard",
+        pay_type="MAGFest-paid", pay_type_key=pay_key, rooms=rooms, nights=1,
+        room_nights=rooms, unit_price_cents=cents // rooms, total_cents=cents,
+        line_status=status,
+    )
+
+
+def test_summary_excludes_rejected_rows():
+    rows = [_row(status="APPROVED"), _row(status="REJECTED", rooms=5, cents=50000)]
+    summary = build_hotel_summary(rows)
+    assert summary["grand_rooms"] == 2
+    assert summary["grand_cents"] == 20000
+
+
+def test_summary_is_empty_when_every_row_is_rejected():
+    summary = build_hotel_summary([_row(status="REJECTED")])
+    assert summary["grand_rooms"] == 0
+    assert summary["matrix_rows"] == []
+
+
+def test_group_sorts_rejected_last_and_excludes_them_from_subtotals():
+    rows = [
+        _row(status="REJECTED", dept="Alpha"),
+        _row(status="APPROVED", dept="Beta"),
+        _row(status="PENDING", dept="Gamma"),
+    ]
+    groups = group_hotel_rows(rows)
+    assert len(groups) == 1
+    g = groups[0]
+    # Rejected sinks to the bottom; the other two keep their original order.
+    assert [r.department_name for r in g["rows"]] == ["Beta", "Gamma", "Alpha"]
+    assert g["room_subtotal"] == 4        # 2 + 2, rejected excluded
+    assert g["cents_subtotal"] == 40000
+    assert g["rejected_count"] == 1
+    assert g["rejected_cents"] == 20000


### PR DESCRIPTION
**exclude rejected hotel rooms and trim the item action row**
Two unrelated fixes found while testing the hotel rooms report.

**Hotel rooms report: rejected lines no longer inflate the numbers**
The summary cross-tab and the per-pay-type subtotals counted rejected lines alongside approved and pending ones. The summary is a planning number, and a rejected room is not a room anyone will book, so the report overstated the event.

Rejected lines now stay out of the summary and out of the group subtotals. They still appear in the breakout table, dimmed and sorted to the bottom of their group, with a line under each group stating how many rejected lines and how many dollars were left out. The filter sits inside build_hotel_summary() rather than at the call site, so a future caller cannot forget it. The Excel export uses the same row order as the page, so the two can be compared line by line. Line status renders through the shared status pill macro instead of raw text.

**Work item detail: drop three duplicated buttons, gate extensions to drafts**
The action row on a budget request carried Assign Reviewers, Review Queue, and Admin Final Queue. None of the three act on the request you are looking at; each one navigates to a queue that is already reachable from the top nav, in the Budget Admin menu for admins and the Review menu for approvers. Removed.

Grant Extension and Revoke Extension now show only while the request is a draft. An extension moves the submission deadline, so it does nothing once the request has been submitted. The badge recording that an extension was granted stays on the page.
